### PR TITLE
Optimize McKay decomposer

### DIFF
--- a/opensquirrel/gates.py
+++ b/opensquirrel/gates.py
@@ -11,7 +11,7 @@ class Semantic:
 
 class SingleQubitAxisAngleSemantic(Semantic):
     def __init__(self, axis: Tuple[float, float, float], angle: float, phase: float):
-        self.axis = self._normalize(np.array(axis).astype(np.float64))
+        self.axis = self._normalize(np.asarray(axis, dtype=np.float64))
         self.angle = angle
         self.phase = phase
 

--- a/opensquirrel/mckay_decomposer.py
+++ b/opensquirrel/mckay_decomposer.py
@@ -10,6 +10,7 @@ from opensquirrel.squirrel_ast import SquirrelAST
 
 FloatArray = npt.NDArray[np.float64]
 
+
 def normalizeAngle(x: float) -> float:
     t = x - 2 * pi * (x // (2 * pi) + 1)
     if t < -pi + ATOL:
@@ -18,10 +19,10 @@ def normalizeAngle(x: float) -> float:
         t -= 2 * pi
     return t
 
-def cross(l : FloatArray, r : FloatArray) -> FloatArray:
-    return np.array( [ l[1] * r[2] - l[2] * r[1],
-                      l[2] * r[0] - l[0] * r[2],
-                      l[0] * r[1] - l[1] * r[0] ], dtype=l.dtype) 
+
+def cross(l: FloatArray, r: FloatArray) -> FloatArray:
+    return np.array([l[1] * r[2] - l[2] * r[1], l[2] * r[0] - l[0] * r[2], l[0] * r[1] - l[1] * r[0]], dtype=l.dtype)
+
 
 class McKayDecomposer:
     def __init__(self, gates):

--- a/opensquirrel/mckay_decomposer.py
+++ b/opensquirrel/mckay_decomposer.py
@@ -2,13 +2,10 @@ from math import acos, atan2, cos, pi, sin, sqrt
 from typing import Tuple
 
 import numpy as np
-import numpy.typing as npt
 
 from opensquirrel.common import ATOL, ArgType
 from opensquirrel.gates import SingleQubitAxisAngleSemantic, queryEntry, querySemantic, querySignature
 from opensquirrel.squirrel_ast import SquirrelAST
-
-FloatArray = npt.NDArray[np.float64]
 
 
 def normalizeAngle(x: float) -> float:
@@ -18,10 +15,6 @@ def normalizeAngle(x: float) -> float:
     elif t > pi:
         t -= 2 * pi
     return t
-
-
-def cross(l: FloatArray, r: FloatArray) -> FloatArray:
-    return np.array([l[1] * r[2] - l[2] * r[1], l[2] * r[0] - l[0] * r[2], l[0] * r[1] - l[1] * r[0]], dtype=l.dtype)
 
 
 class McKayDecomposer:
@@ -99,7 +92,7 @@ class McKayDecomposer:
         combinedAxis = (
             1
             / sin(combinedAngle / 2)
-            * (sin(a / 2) * cos(b / 2) * l + cos(a / 2) * sin(b / 2) * m + sin(a / 2) * sin(b / 2) * cross(l, m))
+            * (sin(a / 2) * cos(b / 2) * l + cos(a / 2) * sin(b / 2) * m + sin(a / 2) * sin(b / 2) * np.cross(l, m))
         )
 
         self.oneQubitGates[qubit] = {"angle": combinedAngle, "axis": combinedAxis, "phase": combinedPhase}

--- a/opensquirrel/mckay_decomposer.py
+++ b/opensquirrel/mckay_decomposer.py
@@ -2,12 +2,13 @@ from math import acos, atan2, cos, pi, sin, sqrt
 from typing import Tuple
 
 import numpy as np
+import numpy.typing as npt
 
 from opensquirrel.common import ATOL, ArgType
 from opensquirrel.gates import SingleQubitAxisAngleSemantic, queryEntry, querySemantic, querySignature
 from opensquirrel.squirrel_ast import SquirrelAST
 
-FloatArray = np.typing.NDArray[np.float64]
+FloatArray = npt.NDArray[np.float64]
 
 def normalizeAngle(x: float) -> float:
     t = x - 2 * pi * (x // (2 * pi) + 1)


### PR DESCRIPTION
The main optimization is the replacement of `np.cross` with a direct calculation for 3d vectors. 

```
# on develop
%timeit myCircuit.decompose_mckay()
1.24 ms ± 54 µs per loop (mean ± std. dev. of 7 runs, 1,000 loops each)
# this PR
In [4]: %timeit myCircuit.decompose_mckay()
686 µs ± 79 µs per loop (mean ± std. dev. of 7 runs, 1,000 loops each)
```

@pablolh 