### PR TITLE
Add special case for single-CNOT decomposition of controlled-U

### DIFF
--- a/opensquirrel/merger.py
+++ b/opensquirrel/merger.py
@@ -16,9 +16,11 @@ def compose_bloch_sphere_rotations(a: BlochSphereRotation, b: BlochSphereRotatio
     """
     assert a.qubit == b.qubit, "Cannot merge two BlochSphereRotation's on different qubits"
 
-    combined_angle = 2 * acos(
-        cos(a.angle / 2) * cos(b.angle / 2) - sin(a.angle / 2) * sin(b.angle / 2) * np.dot(a.axis, b.axis)
-    )
+    acos_argument = cos(a.angle / 2) * cos(b.angle / 2) - sin(a.angle / 2) * sin(b.angle / 2) * np.dot(a.axis, b.axis)
+    # This fixes float approximations like 1.0000000000002 which acos doesn't like.
+    acos_argument = max(min(acos_argument, 1.0), -1.0)
+
+    combined_angle = 2 * acos(acos_argument)
 
     if abs(sin(combined_angle / 2)) < ATOL:
         return BlochSphereRotation.identity(a.qubit)

--- a/test/test_cnot_decomposer.py
+++ b/test/test_cnot_decomposer.py
@@ -29,13 +29,12 @@ class CNOTDecomposerTest(IREqualityTestBase):
     def test_cz(self):
         self.assertEqual(
             CNOTDecomposer.decompose(cz(Qubit(0), Qubit(1))),
-            # FIXME: this should only be H-CNOT-H no? Check https://github.com/QuTech-Delft/OpenSquirrel/issues/99
             [
-                rz(Qubit(1), Float(math.pi / 2)),
+                rz(Qubit(1), Float(math.pi)),
+                ry(Qubit(1), Float(math.pi / 2)),
                 cnot(Qubit(0), Qubit(1)),
-                rz(Qubit(1), Float(-math.pi / 2)),
-                cnot(Qubit(0), Qubit(1)),
-                rz(Qubit(0), Float(math.pi / 2)),
+                ry(Qubit(1), Float(-math.pi / 2)),
+                rz(Qubit(1), Float(math.pi)),
             ],
         )
 


### PR DESCRIPTION
Fix https://github.com/QuTech-Delft/OpenSquirrel/issues/99

This decreases gate count for e.g CNOT decomposition of CZ (which then uses a single CNOT sandwiched by 2 Hadamard gates).

Thanks to @prince-ph0en1x for pointing towards relevant literature, namely https://arxiv.org/abs/quant-ph/9503016