### PR TITLE
152 basic implementation mapper

### DIFF
--- a/opensquirrel/circuit.py
+++ b/opensquirrel/circuit.py
@@ -12,6 +12,7 @@ from opensquirrel.exporter.export_format import ExportFormat
 from opensquirrel.merger import general_merger
 from opensquirrel.parser.libqasm.libqasm_ir_creator import LibqasmIRCreator
 from opensquirrel.squirrel_ir import Gate, Measure, SquirrelIR
+from opensquirrel.mapper import map_qubits, Mapper
 
 
 class Circuit:
@@ -94,6 +95,16 @@ class Circuit:
     def decompose(self, decomposer: Decomposer):
         """Generic decomposition pass. It applies the given decomposer function to every gate in the circuit."""
         general_decomposer.decompose(self.squirrel_ir, decomposer)
+
+    def map_qubits(self, mapper: Mapper) -> None:
+        """Generic qubit mapper pass.
+
+        Maps the virtual qubits of the circuit to physical qubits of the target hardware.
+
+        Args:
+            mapper: Mapper class to use.
+        """
+        map_qubits(self.squirrel_ir, mapper)
 
     def replace(self, gate_generator: Callable[..., Gate], f):
         """Manually replace occurrences of a given gate with a list of gates.

--- a/opensquirrel/circuit.py
+++ b/opensquirrel/circuit.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Callable, Dict
 
 import numpy as np
@@ -9,10 +11,10 @@ from opensquirrel.default_gates import default_gate_aliases, default_gate_set
 from opensquirrel.default_measurements import default_measurement_set
 from opensquirrel.exporter import quantify_scheduler_exporter, writer
 from opensquirrel.exporter.export_format import ExportFormat
+from opensquirrel.mapper import IdentityMapper, Mapper, map_qubits
 from opensquirrel.merger import general_merger
 from opensquirrel.parser.libqasm.libqasm_ir_creator import LibqasmIRCreator
 from opensquirrel.squirrel_ir import Gate, Measure, SquirrelIR
-from opensquirrel.mapper import map_qubits, Mapper
 
 
 class Circuit:
@@ -96,14 +98,15 @@ class Circuit:
         """Generic decomposition pass. It applies the given decomposer function to every gate in the circuit."""
         general_decomposer.decompose(self.squirrel_ir, decomposer)
 
-    def map_qubits(self, mapper: Mapper) -> None:
+    def map_qubits(self, mapper: Mapper | None = None) -> None:
         """Generic qubit mapper pass.
 
         Maps the virtual qubits of the circuit to physical qubits of the target hardware.
 
         Args:
-            mapper: Mapper class to use.
+            mapper: Mapper class to use. If ``None`` (default) is provided, use the ``IdentityMapper``.
         """
+        mapper = IdentityMapper() if mapper is None else mapper
         map_qubits(self.squirrel_ir, mapper)
 
     def replace(self, gate_generator: Callable[..., Gate], f):

--- a/opensquirrel/mapper/__init__.py
+++ b/opensquirrel/mapper/__init__.py
@@ -1,4 +1,4 @@
-from opensquirrel.mapper.general_mapper import map, Mapper
-from opensquirrel.mapper.simple_mappers import IdentityMapper, HardcodedMapper
+from opensquirrel.mapper.general_mapper import Mapper, map_qubits
+from opensquirrel.mapper.simple_mappers import HardcodedMapper, IdentityMapper
 
-__all__ = ["map", "Mapper", "IdentityMapper", "HardcodedMapper"]
+__all__ = ["map_qubits", "Mapper", "IdentityMapper", "HardcodedMapper"]

--- a/opensquirrel/mapper/__init__.py
+++ b/opensquirrel/mapper/__init__.py
@@ -1,0 +1,4 @@
+from opensquirrel.mapper.general_mapper import map, Mapper
+from opensquirrel.mapper.simple_mappers import IdentityMapper, HardcodedMapper
+
+__all__ = ["map", "Mapper", "IdentityMapper", "HardcodedMapper"]

--- a/opensquirrel/mapper/general_mapper.py
+++ b/opensquirrel/mapper/general_mapper.py
@@ -1,13 +1,19 @@
+"""This module contains generic mapping components."""
+
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
 
-import networkx as nx
-
-from opensquirrel.squirrel_ir import ControlledGate, Gate, Measure, SquirrelIR
+from opensquirrel.squirrel_ir import Gate, Measure, SquirrelIR
 
 
-def map_qubits(squirrel_ir: SquirrelIR, mapper: type[Mapper]) -> None:
+def map_qubits(squirrel_ir: SquirrelIR, mapper: Mapper) -> None:
+    """Map the virtual qubits in the `squirrel_ir` to physical qubits using `mapper`.
+
+    Args:
+        squirrel_ir: IR to act on.
+        mapper: Mapping algorithm to use.
+    """
 
     mapping = mapper.map(squirrel_ir)
 
@@ -16,26 +22,16 @@ def map_qubits(squirrel_ir: SquirrelIR, mapper: type[Mapper]) -> None:
             statement.relabel(mapping)
 
 
-def make_interaction_graph(squirrel_ir: SquirrelIR) -> nx.Graph:
-    interaction_graph = nx.Graph()
-    controlled_gates = (statement for statement in squirrel_ir.statements if isinstance(statement, ControlledGate))
-
-    for gate in controlled_gates:
-        target_qubits = gate.target_gate.get_qubit_operands()
-        if len(target_qubits) > 1:
-            raise ValueError(
-                f"The ControlledGate {gate} has multiple target qubits. These must be  decomposed before creating an "
-                "interaction graph."
-            )
-
-        interaction = (gate.control_qubit, target_qubits[0])
-        interaction_graph.add_edge(interaction)
-
-    return interaction_graph
-
-
 class Mapper(ABC):
+    """Base class for the Mapper pass."""
 
     @abstractmethod
     def map(self, squirrel_ir: SquirrelIR) -> dict[int, int]:
-        """Note that the mapper should *not* alter `squirrel_ir`."""
+        """Produce a mapping between thee virtual qubits in the `squirrel_ir` to physical qubits.
+
+        Args:
+            squirrel_ir: IR to map.
+
+        Returns:
+            Dictionary with as keys the virtual qubits and as values the physical qubits.
+        """

--- a/opensquirrel/mapper/general_mapper.py
+++ b/opensquirrel/mapper/general_mapper.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+
+import networkx as nx
+
+from opensquirrel.squirrel_ir import ControlledGate, Gate, Measure, SquirrelIR
+
+
+def map_qubits(squirrel_ir: SquirrelIR, mapper: type[Mapper], *args, **kwargs) -> None:
+
+    mapping = mapper.map(squirrel_ir, *args, **kwargs)
+
+    for statement in squirrel_ir.statements:
+        if isinstance(statement, (Gate, Measure)):
+            statement.relabel(mapping)
+
+
+def make_interaction_graph(squirrel_ir: SquirrelIR) -> nx.Graph:
+    interaction_graph = nx.Graph()
+    controlled_gates = (statement for statement in squirrel_ir.statements if isinstance(statement, ControlledGate))
+
+    for gate in controlled_gates:
+        target_qubits = gate.target_gate.get_qubit_operands()
+        if len(target_qubits) > 1:
+            raise ValueError(
+                f"The ControlledGate {gate} has multiple target qubits. These must be  decomposed before creating an "
+                "interaction graph."
+            )
+
+        interaction = (gate.control_qubit, target_qubits[0])
+        interaction_graph.add_edge(interaction)
+
+    return interaction_graph
+
+
+class Mapper(ABC):
+
+    @abstractmethod
+    def map(self, squirrel_ir: SquirrelIR, *args, **kwargs) -> dict[int, int]:
+        """Note that the mapper should *not* alter `squirrel_ir`."""

--- a/opensquirrel/mapper/general_mapper.py
+++ b/opensquirrel/mapper/general_mapper.py
@@ -7,9 +7,9 @@ import networkx as nx
 from opensquirrel.squirrel_ir import ControlledGate, Gate, Measure, SquirrelIR
 
 
-def map_qubits(squirrel_ir: SquirrelIR, mapper: type[Mapper], *args, **kwargs) -> None:
+def map_qubits(squirrel_ir: SquirrelIR, mapper: type[Mapper]) -> None:
 
-    mapping = mapper.map(squirrel_ir, *args, **kwargs)
+    mapping = mapper.map(squirrel_ir)
 
     for statement in squirrel_ir.statements:
         if isinstance(statement, (Gate, Measure)):
@@ -37,5 +37,5 @@ def make_interaction_graph(squirrel_ir: SquirrelIR) -> nx.Graph:
 class Mapper(ABC):
 
     @abstractmethod
-    def map(self, squirrel_ir: SquirrelIR, *args, **kwargs) -> dict[int, int]:
+    def map(self, squirrel_ir: SquirrelIR) -> dict[int, int]:
         """Note that the mapper should *not* alter `squirrel_ir`."""

--- a/opensquirrel/mapper/simple_mappers.py
+++ b/opensquirrel/mapper/simple_mappers.py
@@ -4,10 +4,11 @@
 * HardcodedMapper
 """
 
-from opensquirrel.mapper.general_mapper import Mapper
-from opensquirrel.squirrel_ir import SquirrelIR
 from collections.abc import Mapping
 from typing import SupportsInt
+
+from opensquirrel.mapper.general_mapper import Mapper
+from opensquirrel.squirrel_ir import SquirrelIR
 
 
 class IdentityMapper(Mapper):

--- a/opensquirrel/mapper/simple_mappers.py
+++ b/opensquirrel/mapper/simple_mappers.py
@@ -14,18 +14,43 @@ from opensquirrel.squirrel_ir import SquirrelIR
 class IdentityMapper(Mapper):
 
     def map(self, squirrel_ir: SquirrelIR) -> dict[int, int]:
+        """Produce an IdentityMapping.
+
+        Args:
+            squirrel_ir: IR to map.
+
+        Returns:
+            Dictionary with as keys the virtual qubits and as values the physical qubits. The dictionary maps each
+            virtual qubit to exactly the same physical qubit.
+        """
         return {i: i for i in range(squirrel_ir.number_of_qubits)}
 
 
 class HardcodedMapper(Mapper):
 
     def __init__(self, mapping: Mapping[SupportsInt, SupportsInt]) -> None:
+        """Init of the ``HardcodedMapper``.
+
+        Args:
+            mapping: Mapping with as keys the virtual qubits and as values the physical qubits.
+
+        Raises:
+            ValueError: If `mapping` is not a valid mapping.
+        """
         # Check if the provided mapping is valid
         self.mapping = {int(virtual_qubit): int(physical_qubit) for virtual_qubit, physical_qubit in mapping.items()}
         if set(self.mapping.keys()) != set(self.mapping.values()):
             raise ValueError("The set of physical qubits is not equal to the set of virtual qubits.")
 
     def map(self, squirrel_ir: SquirrelIR) -> dict[int, int]:
+        """Retrieve tha hardcoded mapping.
+
+        Args:
+            squirrel_ir: IR to map.
+
+        Returns:
+            Dictionary with as keys the virtual qubits and as values the physical qubits.
+        """
         if set(range(squirrel_ir.number_of_qubits)) != set(self.mapping.keys()):
             raise ValueError("Virtual qubits are not labeled correctly.")
 

--- a/opensquirrel/mapper/simple_mappers.py
+++ b/opensquirrel/mapper/simple_mappers.py
@@ -1,0 +1,31 @@
+"""This module contains the following simple mappers:
+
+* IdentityMapper
+* HardcodedMapper
+"""
+
+from opensquirrel.mapper.general_mapper import Mapper
+from opensquirrel.squirrel_ir import SquirrelIR
+from collections.abc import Mapping
+from typing import SupportsInt
+
+
+class IdentityMapper(Mapper):
+
+    def map(self, squirrel_ir: SquirrelIR) -> dict[int, int]:
+        return {i: i for i in range(squirrel_ir.number_of_qubits)}
+
+
+class HardcodedMapper(Mapper):
+
+    def __init__(self, mapping: Mapping[SupportsInt, SupportsInt]) -> None:
+        # Check if the provided mapping is valid
+        self.mapping = {int(virtual_qubit): int(physical_qubit) for virtual_qubit, physical_qubit in mapping.items()}
+        if set(self.mapping.keys()) != set(self.mapping.values()):
+            raise ValueError("The set of physical qubits is not equal to the set of virtual qubits.")
+
+    def map(self, squirrel_ir: SquirrelIR) -> dict[int, int]:
+        if set(range(squirrel_ir.number_of_qubits)) != set(self.mapping.keys()):
+            raise ValueError("Virtual qubits are not labeled correctly.")
+
+        return self.mapping

--- a/opensquirrel/mapper/utils.py
+++ b/opensquirrel/mapper/utils.py
@@ -1,0 +1,22 @@
+import networkx as nx
+
+from opensquirrel.squirrel_ir import Gate, SquirrelIR
+
+
+def make_interaction_graph(squirrel_ir: SquirrelIR) -> nx.Graph:
+
+    interaction_graph = nx.Graph()
+    gates = (statement for statement in squirrel_ir.statements if isinstance(statement, Gate))
+
+    for gate in gates:
+        target_qubits = gate.get_qubit_operands()
+        if len(target_qubits) == 1:
+            continue
+        if len(target_qubits) > 2:
+            raise ValueError(
+                f"The gate {gate} acts on more than 2 qubits. The gate must be decomposed before an interaction graph "
+                "can be made."
+            )
+        interaction_graph.add_edge(*target_qubits)
+
+    return interaction_graph

--- a/opensquirrel/squirrel_ir.py
+++ b/opensquirrel/squirrel_ir.py
@@ -111,7 +111,7 @@ class Measure(Statement, ABC):
     def __eq__(self, other):
         if not isinstance(other, Measure):
             return False
-        return self.qubit == other.qubit and self.axis == other.axis
+        return self.qubit == other.qubit and np.allclose(self.axis, other.axis, atol=ATOL)
 
     def accept(self, visitor: SquirrelIRVisitor):
         visitor.visit_measure(self)

--- a/opensquirrel/squirrel_ir.py
+++ b/opensquirrel/squirrel_ir.py
@@ -260,7 +260,7 @@ class MatrixGate(Gate):
             mapping: Mapping with as keys the indices of the original qubits and as values the indices of the qubits
                 after replacement.
         """
-        self.operands = [Qubit[mapping[qubit.index]] for qubit in self.operands]
+        self.operands = [Qubit(mapping[qubit.index]) for qubit in self.operands]
 
 
 class ControlledGate(Gate):

--- a/opensquirrel/utils/check_passes/__init__.py
+++ b/opensquirrel/utils/check_passes/__init__.py
@@ -1,3 +1,5 @@
+"""Ths subpackage contains compatibility checks for the different compilation passes."""
+
 from opensquirrel.utils.check_passes.check_mapper import check_mapper
 
 __all__ = ["check_mapper"]

--- a/opensquirrel/utils/check_passes/__init__.py
+++ b/opensquirrel/utils/check_passes/__init__.py
@@ -1,0 +1,3 @@
+from opensquirrel.utils.check_passes.check_mapper import check_mapper
+
+__all__ = ["check_mapper"]

--- a/opensquirrel/utils/check_passes/check_mapper.py
+++ b/opensquirrel/utils/check_passes/check_mapper.py
@@ -1,0 +1,43 @@
+from copy import deepcopy
+
+from opensquirrel.mapper.general_mapper import Mapper
+from opensquirrel.squirrel_ir import BlochSphereRotation, Comment, ControlledGate, Measure, Qubit, SquirrelIR
+
+
+def check_mapper(mapper: Mapper) -> None:
+
+    assert isinstance(mapper, Mapper)
+
+    squirrel_ir = SquirrelIR(number_of_qubits=10)
+    _check_scenario(squirrel_ir, deepcopy(mapper))
+
+    squirrel_ir = SquirrelIR(number_of_qubits=10)
+    squirrel_ir.add_comment(Comment("comment"))
+    squirrel_ir.add_gate(BlochSphereRotation(Qubit(42), (1, 0, 0), 1, 2))
+    squirrel_ir.add_gate(ControlledGate(Qubit(42), BlochSphereRotation.identity(Qubit(100))))
+    squirrel_ir.add_measurement(Measure(Qubit(42), (0, 0, 1)))
+    _check_scenario(squirrel_ir, deepcopy(mapper))
+
+
+def _check_scenario(squirrel_ir: SquirrelIR, mapper: Mapper) -> None:
+    squirrel_ir_copy = deepcopy(squirrel_ir)
+    mapping = mapper.map(squirrel_ir)
+
+    assert squirrel_ir == squirrel_ir_copy, "A Mapper pass should not change the SquirrelIR"
+    _check_mapping_format(mapping, squirrel_ir.number_of_qubits)
+
+
+def _check_mapping_format(mapping: dict[int, int], n_qubits: int) -> None:
+    """Check if the mapping has the expected format.
+
+    Args:
+        mapping: Mapping to check.
+        n_qubits: Number of qubits in the circuit.
+    """
+    assert isinstance(
+        mapping, dict
+    ), f"Output mapping should be an instance of <class 'dict'>, but was of type {type(mapping)}"
+    assert set(mapping.keys()) == set(
+        mapping.values()
+    ), "The set of virtual qubits is not equal to the set of phyical qubits."
+    assert set(range(n_qubits)) == set(mapping.keys()), "Virtual qubits are not labeled correctly."

--- a/opensquirrel/utils/check_passes/check_mapper.py
+++ b/opensquirrel/utils/check_passes/check_mapper.py
@@ -1,3 +1,5 @@
+"""This module contains checks for the ``Mapper`` pass."""
+
 from copy import deepcopy
 
 from opensquirrel.mapper.general_mapper import Mapper
@@ -5,6 +7,14 @@ from opensquirrel.squirrel_ir import BlochSphereRotation, Comment, ControlledGat
 
 
 def check_mapper(mapper: Mapper) -> None:
+    """Check if the `mapper` complies with the OpenSquirrel requirements.
+
+    If an implementation of ``Mapper`` passes these checks it should be compatible with the ``Circuit.map_qubits``
+    method.
+
+    Args:
+        mapper: Mapper to check.
+    """
 
     assert isinstance(mapper, Mapper)
 
@@ -20,6 +30,12 @@ def check_mapper(mapper: Mapper) -> None:
 
 
 def _check_scenario(squirrel_ir: SquirrelIR, mapper: Mapper) -> None:
+    """Check if the given scenario can be mapped.
+
+    Args:
+        squirrel_ir: SquirrelIR containing the scenario to check against.
+        mapping: Mapping to check.
+    """
     squirrel_ir_copy = deepcopy(squirrel_ir)
     mapping = mapper.map(squirrel_ir)
 

--- a/test/mapper/test_general_mapper.py
+++ b/test/mapper/test_general_mapper.py
@@ -1,0 +1,51 @@
+import pytest
+
+from opensquirrel.default_gates import CNOT, H
+from opensquirrel.mapper import HardcodedMapper, Mapper, map_qubits
+from opensquirrel.squirrel_ir import Comment, Measure, Qubit, SquirrelIR
+
+
+class TestMapper:
+
+    def test_init(self) -> None:
+        with pytest.raises(TypeError):
+            Mapper()
+
+    def test_implementation(self) -> None:
+
+        class Mapper2(Mapper):
+            pass
+
+        with pytest.raises(TypeError):
+            Mapper2()
+
+        class Mapper3(Mapper2):
+            def map(self, squirrel_ir: SquirrelIR) -> dict[int, int]:
+                return {0: 0}
+
+        Mapper3()
+
+
+def test_map_qubits() -> None:
+    # Build the IR
+    squirrel_ir = SquirrelIR(number_of_qubits=3)
+    squirrel_ir.add_gate(H(Qubit(0)))
+    squirrel_ir.add_gate(CNOT(Qubit(0), Qubit(1)))
+    squirrel_ir.add_gate(CNOT(Qubit(1), Qubit(2)))
+    squirrel_ir.add_comment(Comment("Qubit[1]"))
+    squirrel_ir.add_measurement(Measure(Qubit(0), axis=(0, 0, 1)))
+
+    # Map the circuit
+    mapper = HardcodedMapper({0: 1, 1: 0, 2: 2})
+    map_qubits(squirrel_ir, mapper)
+
+    # Check that the circuit is altered as expected
+    mapped_statements = squirrel_ir.statements
+    expected_statements = [
+        H(Qubit(1)),
+        CNOT(Qubit(1), Qubit(0)),
+        CNOT(Qubit(0), Qubit(2)),
+        Comment("Qubit[1]"),
+        Measure(Qubit(1), axis=(0, 0, 1)),
+    ]
+    assert mapped_statements == expected_statements

--- a/test/mapper/test_general_mapper.py
+++ b/test/mapper/test_general_mapper.py
@@ -1,8 +1,9 @@
 import pytest
 
+from opensquirrel import Circuit
 from opensquirrel.default_gates import CNOT, H
 from opensquirrel.mapper import HardcodedMapper, Mapper, map_qubits
-from opensquirrel.squirrel_ir import Comment, Measure, Qubit, SquirrelIR
+from opensquirrel.squirrel_ir import Comment, Measure, Qubit, SquirrelIR, Statement
 
 
 class TestMapper:
@@ -26,26 +27,42 @@ class TestMapper:
         Mapper3()
 
 
-def test_map_qubits() -> None:
-    # Build the IR
-    squirrel_ir = SquirrelIR(number_of_qubits=3)
-    squirrel_ir.add_gate(H(Qubit(0)))
-    squirrel_ir.add_gate(CNOT(Qubit(0), Qubit(1)))
-    squirrel_ir.add_gate(CNOT(Qubit(1), Qubit(2)))
-    squirrel_ir.add_comment(Comment("Qubit[1]"))
-    squirrel_ir.add_measurement(Measure(Qubit(0), axis=(0, 0, 1)))
+class TestMapQubits:
 
-    # Map the circuit
-    mapper = HardcodedMapper({0: 1, 1: 0, 2: 2})
-    map_qubits(squirrel_ir, mapper)
+    @pytest.fixture(name="squirrel_ir")
+    def squirrel_ir_fixture(self) -> SquirrelIR:
+        squirrel_ir = SquirrelIR(number_of_qubits=3)
+        squirrel_ir.add_gate(H(Qubit(0)))
+        squirrel_ir.add_gate(CNOT(Qubit(0), Qubit(1)))
+        squirrel_ir.add_gate(CNOT(Qubit(1), Qubit(2)))
+        squirrel_ir.add_comment(Comment("Qubit[1]"))
+        squirrel_ir.add_measurement(Measure(Qubit(0), axis=(0, 0, 1)))
+        return squirrel_ir
 
-    # Check that the circuit is altered as expected
-    mapped_statements = squirrel_ir.statements
-    expected_statements = [
-        H(Qubit(1)),
-        CNOT(Qubit(1), Qubit(0)),
-        CNOT(Qubit(0), Qubit(2)),
-        Comment("Qubit[1]"),
-        Measure(Qubit(1), axis=(0, 0, 1)),
-    ]
-    assert mapped_statements == expected_statements
+    @pytest.fixture(name="expected_statements")
+    def expected_statements_fixture(self) -> list[Statement]:
+        return [
+            H(Qubit(1)),
+            CNOT(Qubit(1), Qubit(0)),
+            CNOT(Qubit(0), Qubit(2)),
+            Comment("Qubit[1]"),
+            Measure(Qubit(1), axis=(0, 0, 1)),
+        ]
+
+    def test_map_qubits(self, squirrel_ir: SquirrelIR, expected_statements: list[Statement]) -> None:
+        mapper = HardcodedMapper({0: 1, 1: 0, 2: 2})
+        map_qubits(squirrel_ir, mapper)
+
+        # Check that the circuit is altered as expected
+        mapped_statements = squirrel_ir.statements
+        assert mapped_statements == expected_statements
+
+    def test_map_qubits_circuit(self, squirrel_ir: SquirrelIR, expected_statements: list[Statement]) -> None:
+        circuit = Circuit(squirrel_ir)
+
+        mapper = HardcodedMapper({0: 1, 1: 0, 2: 2})
+        circuit.map_qubits(mapper)
+
+        # Check that the circuit is altered as expected
+        mapped_statements = circuit.squirrel_ir.statements
+        assert mapped_statements == expected_statements

--- a/test/mapper/test_simple_mappers.py
+++ b/test/mapper/test_simple_mappers.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import pytest
+
+from opensquirrel.mapper import HardcodedMapper, IdentityMapper
+from opensquirrel.squirrel_ir import SquirrelIR
+from opensquirrel.utils.check_passes import check_mapper
+
+
+class TestIdentityMapper:
+    @pytest.fixture(name="mapper")
+    def mapper_fixture(self) -> IdentityMapper:
+        return IdentityMapper()
+
+    def test_compliance(self, mapper: IdentityMapper) -> None:
+        check_mapper(mapper)
+
+    def test_mapping(self, mapper: IdentityMapper) -> None:
+        squirrel_ir = SquirrelIR(number_of_qubits=3)
+        mapping = mapper.map(squirrel_ir)
+        assert mapping == {0: 0, 1: 1, 2: 2}
+
+
+class TestHardcodedMapper:
+
+    @pytest.fixture(name="mapper")
+    def mapper_fixture(self) -> HardcodedMapper:
+        mapping = {i: (i + 1) % 10 for i in range(10)}
+        return HardcodedMapper(mapping)
+
+    def test_compliance(self, mapper: HardcodedMapper) -> None:
+        check_mapper(mapper)
+
+    def test_mapping(self, mapper: HardcodedMapper) -> None:
+        squirrel_ir = SquirrelIR(number_of_qubits=10)
+        mapping = mapper.map(squirrel_ir)
+        assert mapping == {0: 1, 1: 2, 2: 3, 3: 4, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 0}
+
+    @pytest.mark.parametrize("incorrect_mapping", [{0: 0, 1: 0}, {0: 1}])
+    def test_errors(self, incorrect_mapping: dict[int, int]) -> None:
+        with pytest.raises(ValueError):
+            HardcodedMapper(incorrect_mapping)

--- a/test/test_squirrel_ir.py
+++ b/test/test_squirrel_ir.py
@@ -1,101 +1,128 @@
-import unittest
+from __future__ import annotations
+
+import math
 
 import numpy as np
+import pytest
 
-from opensquirrel.default_gates import *
+from opensquirrel.squirrel_ir import BlochSphereRotation, ControlledGate, MatrixGate, Measure, Qubit
 
 
-class SquirrelIRTest(unittest.TestCase):
+class TestSquirrelIR:
     def test_cnot_equality(self):
-        cnot_matrix_gate = MatrixGate(
-            np.array(
-                [
-                    [1, 0, 0, 0],
-                    [0, 1, 0, 0],
-                    [0, 0, 0, 1],
-                    [0, 0, 1, 0],
-                ]
-            ),
-            operands=[Qubit(4), Qubit(100)],
+        matrix = np.array(
+            [
+                [1, 0, 0, 0],
+                [0, 1, 0, 0],
+                [0, 0, 0, 1],
+                [0, 0, 1, 0],
+            ]
         )
+        cnot_matrix_gate = MatrixGate(matrix, operands=[Qubit(4), Qubit(100)])
 
         cnot_controlled_gate = ControlledGate(
             Qubit(4), BlochSphereRotation(qubit=Qubit(100), axis=(1, 0, 0), angle=math.pi, phase=math.pi / 2)
         )
 
-        self.assertTrue(cnot_controlled_gate == cnot_matrix_gate)
-
-    def test_cnot_inequality(self):
-        swap_matrix_gate = MatrixGate(
-            np.array(
-                [
-                    [1, 0, 0, 0],
-                    [0, 0, 1, 0],
-                    [0, 1, 0, 0],
-                    [0, 0, 0, 1],
-                ]
-            ),
-            operands=[Qubit(4), Qubit(100)],
-        )
-
-        cnot_controlled_gate = ControlledGate(
-            Qubit(4), BlochSphereRotation(qubit=Qubit(100), axis=(1, 0, 0), angle=math.pi, phase=math.pi / 2)
-        )
-
-        self.assertFalse(cnot_controlled_gate == swap_matrix_gate)
+        assert cnot_controlled_gate == cnot_matrix_gate
 
     def test_different_qubits_gate(self):
-        large_identity_matrix_gate = MatrixGate(
-            np.array(
-                [
-                    [1, 0, 0, 0],
-                    [0, 1, 0, 0],
-                    [0, 0, 1, 0],
-                    [0, 0, 0, 1],
-                ]
-            ),
-            operands=[Qubit(0), Qubit(2)],
+        matrix = np.array(
+            [
+                [1, 0, 0, 0],
+                [0, 1, 0, 0],
+                [0, 0, 1, 0],
+                [0, 0, 0, 1],
+            ]
         )
+        large_identity_matrix_gate = MatrixGate(matrix, operands=[Qubit(0), Qubit(2)])
         small_identity_control_gate = ControlledGate(
             Qubit(4), BlochSphereRotation(qubit=Qubit(2), axis=(1, 0, 0), angle=0, phase=0)
         )
 
-        self.assertTrue(large_identity_matrix_gate == small_identity_control_gate)
+        assert large_identity_matrix_gate == small_identity_control_gate
 
     def test_inverse_gate(self):
-        inverted_matrix_gate = MatrixGate(
-            np.array(
-                [
-                    [1, 0, 0, 0],
-                    [0, 0, 0, 1],
-                    [0, 0, 1, 0],
-                    [0, 1, 0, 0],
-                ]
-            ),
-            operands=[Qubit(0), Qubit(1)],
+        matrix = np.array(
+            [
+                [1, 0, 0, 0],
+                [0, 0, 0, 1],
+                [0, 0, 1, 0],
+                [0, 1, 0, 0],
+            ]
         )
+        inverted_matrix_gate = MatrixGate(matrix, operands=[Qubit(0), Qubit(1)])
 
         inverted_cnot_gate = ControlledGate(
             Qubit(1), BlochSphereRotation(qubit=Qubit(0), axis=(1, 0, 0), angle=math.pi, phase=math.pi / 2)
         )
 
-        self.assertTrue(inverted_matrix_gate == inverted_cnot_gate)
+        assert inverted_matrix_gate == inverted_cnot_gate
 
     def test_global_phase(self):
-        inverted_matrix_with_phase = MatrixGate(
-            np.array(
-                [
-                    [1j, 0, 0, 0],
-                    [0, 0, 0, 1j],
-                    [0, 0, 1j, 0],
-                    [0, 1j, 0, 0],
-                ]
-            ),
-            operands=[Qubit(0), Qubit(1)],
+        matrix = np.array(
+            [
+                [1j, 0, 0, 0],
+                [0, 0, 0, 1j],
+                [0, 0, 1j, 0],
+                [0, 1j, 0, 0],
+            ]
         )
+        inverted_matrix_with_phase = MatrixGate(matrix, operands=[Qubit(0), Qubit(1)])
 
         inverted_cnot_gate = ControlledGate(
             Qubit(1), BlochSphereRotation(qubit=Qubit(0), axis=(1, 0, 0), angle=math.pi, phase=math.pi / 2)
         )
 
-        self.assertTrue(inverted_matrix_with_phase == inverted_cnot_gate)
+        assert inverted_matrix_with_phase == inverted_cnot_gate
+
+    def test_cnot_inequality(self):
+        matrix = np.array(
+            [
+                [1, 0, 0, 0],
+                [0, 0, 1, 0],
+                [0, 1, 0, 0],
+                [0, 0, 0, 1],
+            ]
+        )
+        swap_matrix_gate = MatrixGate(matrix, operands=[Qubit(4), Qubit(100)])
+
+        cnot_controlled_gate = ControlledGate(
+            Qubit(4), BlochSphereRotation(qubit=Qubit(100), axis=(1, 0, 0), angle=math.pi, phase=math.pi / 2)
+        )
+
+        assert cnot_controlled_gate != swap_matrix_gate
+
+
+class TestMeasure:
+
+    @pytest.fixture(name="measure")
+    def measure_fixture(self) -> Measure:
+        return Measure(Qubit(42), axis=(0, 0, 1))
+
+    def test_repr_dunder(self, measure: Measure) -> None:
+        expected_repr = "Measure(Qubit[42], axis=[0. 0. 1.])"
+        assert repr(measure) == expected_repr
+
+    def test_equality(self, measure: Measure) -> None:
+        measure_eq = Measure(Qubit(42), axis=(0, 0, 1))
+        assert measure == measure_eq
+
+    @pytest.mark.parametrize(
+        "other_measure",
+        [Measure(Qubit(43), axis=(0, 0, 1)), Measure(Qubit(42), axis=(1, 0, 0)), "test"],
+        ids=["qubit", "axis", "type"],
+    )
+    def test_inequality(self, measure: Measure, other_measure: Measure | str) -> None:
+        assert measure != other_measure
+
+    def test_get_qubit_operands(self, measure: Measure) -> None:
+        assert measure.get_qubit_operands() == [Qubit(42)]
+
+    @pytest.mark.parametrize(
+        "mapping, expected_output",
+        [({42: 42}, Measure(Qubit(42), axis=(0, 0, 1))), ({42: 0}, Measure(Qubit(0), axis=(0, 0, 1)))],
+    )
+    def test_relabel(self, measure: Measure, mapping: dict[int, int], expected_output: Measure) -> None:
+        measure.relabel(mapping)
+        assert measure == expected_output


### PR DESCRIPTION
This Pull Request includes: 
- Abstract Base Class for the mapping part of the Mapper pass
- An `IdentityMapper`. Mapping the first virtual qubit to the first physical qubit, etc.
- An `HardcodedMapper`. Map using a predefined (hardcoded) mapping.
- Standardized tests for the Mapper class. Checks barebones of what we require of a `Mapper`.
- Use the output of the Mapper class in a mapper pass on the `Circuit` object.

This also includes the following bugfix:
- `__eq__` of `Measure` no longer returns an array of bools.


Closes #152 