### PR TITLE
215 unittest to pytest

### DIFF
--- a/test/decomposer/test_cnot_decomposer.py
+++ b/test/decomposer/test_cnot_decomposer.py
@@ -1,43 +1,46 @@
-import unittest
-from test.ir_equality_test_base import IREqualityTestBase
+from __future__ import annotations
+
+import math
+
+import pytest
 
 from opensquirrel.decomposer.cnot_decomposer import CNOTDecomposer
-from opensquirrel.default_gates import *
-from opensquirrel.ir import Float, Qubit
+from opensquirrel.default_gates import CNOT, CZ, SWAP, ControlledGate, H, Ry, Rz, X
+from opensquirrel.ir import Float, Gate, Qubit
 
 
-class CNOTDecomposerTest(IREqualityTestBase):
-    def test_ignores_1q_gates(self):
-        self.assertEqual(CNOTDecomposer().decompose(H(Qubit(0))), [H(Qubit(0))])
-        self.assertEqual(CNOTDecomposer().decompose(Rz(Qubit(0), Float(2.345))), [Rz(Qubit(0), Float(2.345))])
-
-    def test_ignores_matrix_gate(self):
-        self.assertEqual(CNOTDecomposer().decompose(SWAP(Qubit(4), Qubit(3))), [SWAP(Qubit(4), Qubit(3))])
-
-    def test_ignores_double_controlled(self):
-        g = ControlledGate(
-            control_qubit=Qubit(5), target_gate=ControlledGate(control_qubit=Qubit(2), target_gate=X(Qubit(0)))
-        )
-        self.assertEqual(CNOTDecomposer().decompose(g), [g])
-
-    def test_CNOT(self):
-        self.assertEqual(
-            CNOTDecomposer().decompose(CNOT(Qubit(0), Qubit(1))),
-            [CNOT(Qubit(0), Qubit(1))],
-        )
-
-    def test_CZ(self):
-        self.assertEqual(
-            CNOTDecomposer().decompose(CZ(Qubit(0), Qubit(1))),
-            [
-                Rz(Qubit(1), Float(math.pi)),
-                Ry(Qubit(1), Float(math.pi / 2)),
-                CNOT(Qubit(0), Qubit(1)),
-                Ry(Qubit(1), Float(-math.pi / 2)),
-                Rz(Qubit(1), Float(math.pi)),
-            ],
-        )
+@pytest.fixture(name="decomposer")
+def decomposer_fixture() -> CNOTDecomposer:
+    return CNOTDecomposer()
 
 
-if __name__ == "__main__":
-    unittest.main()
+@pytest.mark.parametrize(
+    "gate,expected_result", [(H(Qubit(0)), [H(Qubit(0))]), (Rz(Qubit(0), Float(2.345)), [Rz(Qubit(0), Float(2.345))])]
+)
+def test_ignores_1q_gates(decomposer: CNOTDecomposer, gate: Gate, expected_result: list[Gate]) -> None:
+    assert decomposer.decompose(gate) == expected_result
+
+
+def test_ignores_matrix_gate(decomposer: CNOTDecomposer) -> None:
+    assert decomposer.decompose(SWAP(Qubit(4), Qubit(3))) == [SWAP(Qubit(4), Qubit(3))]
+
+
+def test_ignores_double_controlled(decomposer: CNOTDecomposer) -> None:
+    g = ControlledGate(
+        control_qubit=Qubit(5), target_gate=ControlledGate(control_qubit=Qubit(2), target_gate=X(Qubit(0)))
+    )
+    assert decomposer.decompose(g) == [g]
+
+
+def test_CNOT(decomposer: CNOTDecomposer) -> None:
+    assert decomposer.decompose(CNOT(Qubit(0), Qubit(1))) == [CNOT(Qubit(0), Qubit(1))]
+
+
+def test_CZ(decomposer: CNOTDecomposer) -> None:
+    assert decomposer.decompose(CZ(Qubit(0), Qubit(1))) == [
+        Rz(Qubit(1), Float(math.pi)),
+        Ry(Qubit(1), Float(math.pi / 2)),
+        CNOT(Qubit(0), Qubit(1)),
+        Ry(Qubit(1), Float(-math.pi / 2)),
+        Rz(Qubit(1), Float(math.pi)),
+    ]

--- a/test/decomposer/test_mckay_decomposer.py
+++ b/test/decomposer/test_mckay_decomposer.py
@@ -1,72 +1,63 @@
-import unittest
-from test.ir_equality_test_base import IREqualityTestBase
+import math
+
+import pytest
 
 from opensquirrel.decomposer.mckay_decomposer import McKayDecomposer
-from opensquirrel.default_gates import *
-from opensquirrel.ir import Float, Qubit
+from opensquirrel.default_gates import CNOT, CR, X90, H, Rz, X, Y, Z
+from opensquirrel.ir import BlochSphereRotation, Float, Qubit
 
 
-class DecomposeMcKayTests(IREqualityTestBase):
-    def test_ignores_2q_gates(self):
-        self.assertEqual(McKayDecomposer().decompose(CNOT(Qubit(0), Qubit(1))), [CNOT(Qubit(0), Qubit(1))])
-        self.assertEqual(
-            McKayDecomposer().decompose(CR(Qubit(2), Qubit(3), Float(2.123))), [CR(Qubit(2), Qubit(3), Float(2.123))]
-        )
-
-    def test_identity_empty_decomposition(self):
-        self.assertEqual(McKayDecomposer().decompose(BlochSphereRotation.identity(Qubit(0))), [])
-
-    def test_x(self):
-        self.assertEqual(
-            McKayDecomposer().decompose(X(Qubit(0))),
-            [
-                # FIXME: we can do better here. See https://github.com/QuTech-Delft/OpenSquirrel/issues/89.
-                Rz(Qubit(0), Float(-math.pi / 2)),
-                X90(Qubit(0)),
-                X90(Qubit(0)),
-                Rz(Qubit(0), Float(-math.pi / 2)),
-            ],
-        )
-
-    def test_y(self):
-        self.assertEqual(
-            McKayDecomposer().decompose(Y(Qubit(0))), [Rz(Qubit(0), Float(math.pi)), X90(Qubit(0)), X90(Qubit(0))]
-        )
-
-    def test_z(self):
-        self.assertEqual(
-            McKayDecomposer().decompose(Z(Qubit(0))),
-            [
-                Rz(Qubit(0), Float(-math.pi / 2)),
-                X90(Qubit(0)),
-                Rz(Qubit(0), Float(math.pi)),
-                X90(Qubit(0)),
-                Rz(Qubit(0), Float(math.pi / 2)),
-            ],
-        )
-
-    def test_hadamard(self):
-        self.assertEqual(
-            McKayDecomposer().decompose(H(Qubit(0))),
-            [
-                BlochSphereRotation(Qubit(0), axis=(1, 0, 0), angle=math.pi / 2, phase=0.0),
-                BlochSphereRotation(Qubit(0), axis=(0, 0, 1), angle=math.pi / 2, phase=0.0),
-                BlochSphereRotation(Qubit(0), axis=(1, 0, 0), angle=math.pi / 2, phase=0.0),
-            ],
-        )
-
-    def test_arbitrary(self):
-        self.assertEqual(
-            McKayDecomposer().decompose(BlochSphereRotation(qubit=Qubit(0), angle=5.21, axis=(1, 2, 3), phase=0.324)),
-            [
-                Rz(Qubit(0), Float(0.018644578210707863)),
-                X90(Qubit(0)),
-                Rz(Qubit(0), Float(2.520651583905213)),
-                X90(Qubit(0)),
-                Rz(Qubit(0), Float(2.2329420137988887)),
-            ],
-        )
+@pytest.fixture(name="decomposer")
+def decomposer_fixture() -> McKayDecomposer:
+    return McKayDecomposer()
 
 
-if __name__ == "__main__":
-    unittest.main()
+def test_ignores_2q_gates(decomposer: McKayDecomposer) -> None:
+    assert decomposer.decompose(CNOT(Qubit(0), Qubit(1))) == [CNOT(Qubit(0), Qubit(1))]
+    assert decomposer.decompose(CR(Qubit(2), Qubit(3), Float(2.123))) == [CR(Qubit(2), Qubit(3), Float(2.123))]
+
+
+def test_identity_empty_decomposition(decomposer: McKayDecomposer) -> None:
+    assert decomposer.decompose(BlochSphereRotation.identity(Qubit(0))) == []
+
+
+def test_x(decomposer: McKayDecomposer) -> None:
+    assert decomposer.decompose(X(Qubit(0))) == [
+        # FIXME: we can do better here. See https://github.com/QuTech-Delft/OpenSquirrel/issues/89.
+        Rz(Qubit(0), Float(-math.pi / 2)),
+        X90(Qubit(0)),
+        X90(Qubit(0)),
+        Rz(Qubit(0), Float(-math.pi / 2)),
+    ]
+
+
+def test_y(decomposer: McKayDecomposer) -> None:
+    assert decomposer.decompose(Y(Qubit(0))) == [Rz(Qubit(0), Float(math.pi)), X90(Qubit(0)), X90(Qubit(0))]
+
+
+def test_z(decomposer: McKayDecomposer) -> None:
+    assert decomposer.decompose(Z(Qubit(0))) == [
+        Rz(Qubit(0), Float(-math.pi / 2)),
+        X90(Qubit(0)),
+        Rz(Qubit(0), Float(math.pi)),
+        X90(Qubit(0)),
+        Rz(Qubit(0), Float(math.pi / 2)),
+    ]
+
+
+def test_hadamard(decomposer: McKayDecomposer) -> None:
+    assert decomposer.decompose(H(Qubit(0))) == [
+        BlochSphereRotation(Qubit(0), axis=(1, 0, 0), angle=math.pi / 2, phase=0.0),
+        BlochSphereRotation(Qubit(0), axis=(0, 0, 1), angle=math.pi / 2, phase=0.0),
+        BlochSphereRotation(Qubit(0), axis=(1, 0, 0), angle=math.pi / 2, phase=0.0),
+    ]
+
+
+def test_arbitrary(decomposer: McKayDecomposer) -> None:
+    assert decomposer.decompose(BlochSphereRotation(qubit=Qubit(0), angle=5.21, axis=(1, 2, 3), phase=0.324)) == [
+        Rz(Qubit(0), Float(0.018644578210707863)),
+        X90(Qubit(0)),
+        Rz(Qubit(0), Float(2.520651583905213)),
+        X90(Qubit(0)),
+        Rz(Qubit(0), Float(2.2329420137988887)),
+    ]

--- a/test/ir_equality_test_base.py
+++ b/test/ir_equality_test_base.py
@@ -1,40 +1,22 @@
-import unittest
+from __future__ import annotations
 
-from opensquirrel import circuit_matrix_calculator
-from opensquirrel.circuit import Circuit
+from collections.abc import Callable
+from typing import Any
+
+import numpy as np
+from numpy.typing import NDArray
+
+from opensquirrel import Circuit, circuit_matrix_calculator
 from opensquirrel.common import are_matrices_equivalent_up_to_global_phase
 
 
-class IREqualityTestBase(unittest.TestCase):
-    def check_equivalence_up_to_global_phase(self, matrix_a, matrix_b):
-        self.assertTrue(are_matrices_equivalent_up_to_global_phase(matrix_a, matrix_b))
-
-    def modify_circuit_and_check(self, circuit, action, expected_circuit=None):
-        """
-        Checks whether the action preserves:
-        - the number of qubits,
-        - the qubit register name(s),
-        - the circuit matrix up to a global phase factor.
-        """
-        # Store matrix before decompositions.
-        expected_matrix = circuit_matrix_calculator.get_circuit_matrix(circuit)
-
-        action(circuit)
-
-        # Get matrix after decompositions.
-        actual_matrix = circuit_matrix_calculator.get_circuit_matrix(circuit)
-
-        self.check_equivalence_up_to_global_phase(actual_matrix, expected_matrix)
-
-        if expected_circuit is not None:
-            self.assertEqual(circuit, expected_circuit)
-
-
-def check_equivalence_up_to_global_phase(matrix_a, matrix_b):
+def check_equivalence_up_to_global_phase(matrix_a: NDArray[np.complex_], matrix_b: NDArray[np.complex_]) -> None:
     assert are_matrices_equivalent_up_to_global_phase(matrix_a, matrix_b)
 
 
-def modify_circuit_and_check(circuit, action, expected_circuit=None):
+def modify_circuit_and_check(
+    circuit: Circuit, action: Callable[[Circuit, Any]], expected_circuit: Circuit | None = None
+):
     """
     Checks whether the action preserves:
     - the number of qubits,

--- a/test/ir_equality_test_base.py
+++ b/test/ir_equality_test_base.py
@@ -28,3 +28,28 @@ class IREqualityTestBase(unittest.TestCase):
 
         if expected_circuit is not None:
             self.assertEqual(circuit, expected_circuit)
+
+
+def check_equivalence_up_to_global_phase(matrix_a, matrix_b):
+    assert are_matrices_equivalent_up_to_global_phase(matrix_a, matrix_b)
+
+
+def modify_circuit_and_check(circuit, action, expected_circuit=None):
+    """
+    Checks whether the action preserves:
+    - the number of qubits,
+    - the qubit register name(s),
+    - the circuit matrix up to a global phase factor.
+    """
+    # Store matrix before decompositions.
+    expected_matrix = circuit_matrix_calculator.get_circuit_matrix(circuit)
+
+    action(circuit)
+
+    # Get matrix after decompositions.
+    actual_matrix = circuit_matrix_calculator.get_circuit_matrix(circuit)
+
+    check_equivalence_up_to_global_phase(actual_matrix, expected_matrix)
+
+    if expected_circuit is not None:
+        assert circuit == expected_circuit

--- a/test/mapper/test_qubit_remapper.py
+++ b/test/mapper/test_qubit_remapper.py
@@ -1,5 +1,3 @@
-from typing import List
-
 import pytest
 
 from opensquirrel.circuit import Circuit

--- a/test/merger/test_merger.py
+++ b/test/merger/test_merger.py
@@ -1,124 +1,125 @@
-import unittest
-from test.ir_equality_test_base import IREqualityTestBase
+import math
+from test.ir_equality_test_base import modify_circuit_and_check
 
 from opensquirrel.circuit import Circuit
-from opensquirrel.default_gates import *
-from opensquirrel.ir import IR, Float, Qubit
+from opensquirrel.default_gates import CNOT, H, Rx, Ry, Rz
+from opensquirrel.ir import IR, BlochSphereRotation, Float, Qubit
 from opensquirrel.merger import general_merger
 from opensquirrel.merger.general_merger import compose_bloch_sphere_rotations
 from opensquirrel.register_manager import RegisterManager
 
 
-class MergerTest(IREqualityTestBase):
-    def test_compose_bloch_sphere_rotations_same_axis(self):
-        q = Qubit(123)
-        a = BlochSphereRotation(qubit=q, axis=(1, 2, 3), angle=0.4)
-        b = BlochSphereRotation(qubit=q, axis=(1, 2, 3), angle=-0.3)
-        composed = compose_bloch_sphere_rotations(a, b)
-        self.assertEqual(composed, BlochSphereRotation(qubit=q, axis=(1, 2, 3), angle=0.1))
-
-    def test_compose_bloch_sphere_rotations_different_axis(self):
-        # Visualizing this in 3D is difficult...
-        q = Qubit(123)
-        a = BlochSphereRotation(qubit=q, axis=(1, 0, 0), angle=math.pi / 2)
-        b = BlochSphereRotation(qubit=q, axis=(0, 0, 1), angle=-math.pi / 2)
-        c = BlochSphereRotation(qubit=q, axis=(0, 1, 0), angle=math.pi / 2)
-        composed = compose_bloch_sphere_rotations(a, compose_bloch_sphere_rotations(b, c))
-        self.assertEqual(composed, BlochSphereRotation(qubit=q, axis=(1, 1, 0), angle=math.pi))
-
-    def test_single_gate(self):
-        register_manager = RegisterManager(qubit_register_size=2)
-        ir = IR()
-        ir.add_gate(Ry(Qubit(0), Float(1.2345)))
-        circuit = Circuit(register_manager, ir)
-
-        expected_ir = IR()
-        expected_ir.add_gate(Ry(Qubit(0), Float(1.2345)))
-        expected_circuit = Circuit(register_manager, expected_ir)
-
-        self.modify_circuit_and_check(circuit, general_merger.merge_single_qubit_gates, expected_circuit)
-
-        # Check that when no fusion happens, generator and arguments of gates are preserved.
-        self.assertEqual(ir.statements[0].generator, Ry)
-        self.assertEqual(ir.statements[0].arguments, (Qubit(0), Float(1.2345)))
-
-    def test_two_hadamards(self):
-        register_manager = RegisterManager(qubit_register_size=4)
-        ir = IR()
-        ir.add_gate(H(Qubit(2)))
-        ir.add_gate(H(Qubit(2)))
-        circuit = Circuit(register_manager, ir)
-
-        expected_ir = IR()
-        expected_circuit = Circuit(register_manager, expected_ir)
-
-        self.modify_circuit_and_check(circuit, general_merger.merge_single_qubit_gates, expected_circuit)
-
-    def test_two_hadamards_different_qubits(self):
-        register_manager = RegisterManager(qubit_register_size=4)
-        ir = IR()
-        ir.add_gate(H(Qubit(0)))
-        ir.add_gate(H(Qubit(2)))
-        circuit = Circuit(register_manager, ir)
-
-        expected_ir = IR()
-        expected_ir.add_gate(H(Qubit(0)))
-        expected_ir.add_gate(H(Qubit(2)))
-        expected_circuit = Circuit(register_manager, expected_ir)
-
-        self.modify_circuit_and_check(circuit, general_merger.merge_single_qubit_gates, expected_circuit)
-
-    def test_merge_different_qubits(self):
-        register_manager = RegisterManager(qubit_register_size=4)
-        ir = IR()
-        ir.add_gate(Ry(Qubit(0), Float(math.pi / 2)))
-        ir.add_gate(Rx(Qubit(0), Float(math.pi)))
-        ir.add_gate(Rz(Qubit(1), Float(1.2345)))
-        ir.add_gate(Ry(Qubit(2), Float(1)))
-        ir.add_gate(Ry(Qubit(2), Float(3.234)))
-        circuit = Circuit(register_manager, ir)
-
-        expected_ir = IR()
-        expected_ir.add_gate(
-            BlochSphereRotation(qubit=Qubit(0), axis=(1, 0, 1), angle=math.pi)
-        )  # This is hadamard with 0 phase...
-        expected_ir.add_gate(Rz(Qubit(1), Float(1.2345)))
-        expected_ir.add_gate(Ry(Qubit(2), Float(4.234)))
-        expected_circuit = Circuit(register_manager, expected_ir)
-
-        self.modify_circuit_and_check(circuit, general_merger.merge_single_qubit_gates, expected_circuit)
-
-        self.assertTrue(ir.statements[0].is_anonymous)  # When fusion happens, the resulting gate is anonymous.
-        self.assertEqual(ir.statements[1].generator, Rz)  # Otherwise it keeps the same generator and arguments.
-        self.assertEqual(ir.statements[1].arguments, (Qubit(1), Float(1.2345)))
-        self.assertTrue(ir.statements[2].is_anonymous)
-
-    def test_merge_and_flush(self):
-        register_manager = RegisterManager(qubit_register_size=4)
-        ir = IR()
-        ir.add_gate(Ry(Qubit(0), Float(math.pi / 2)))
-        ir.add_gate(Rz(Qubit(1), Float(1.5)))
-        ir.add_gate(Rx(Qubit(0), Float(math.pi)))
-        ir.add_gate(Rz(Qubit(1), Float(-2.5)))
-        ir.add_gate(CNOT(Qubit(0), Qubit(1)))
-        ir.add_gate(Ry(Qubit(0), Float(3.234)))
-        circuit = Circuit(register_manager, ir)
-
-        expected_ir = IR()
-        expected_ir.add_gate(
-            BlochSphereRotation(qubit=Qubit(0), axis=(1, 0, 1), angle=math.pi)
-        )  # This is hadamard with 0 phase...
-        expected_ir.add_gate(Rz(Qubit(1), Float(-1.0)))
-        expected_ir.add_gate(CNOT(Qubit(0), Qubit(1)))
-        expected_ir.add_gate(Ry(Qubit(0), Float(3.234)))
-        expected_circuit = Circuit(register_manager, expected_ir)
-
-        self.modify_circuit_and_check(circuit, general_merger.merge_single_qubit_gates, expected_circuit)
-
-        self.assertTrue(ir.statements[0].is_anonymous)
-        self.assertEqual(ir.statements[3].generator, Ry)
-        self.assertEqual(ir.statements[3].arguments, (Qubit(0), Float(3.234)))
+def test_compose_bloch_sphere_rotations_same_axis() -> None:
+    q = Qubit(123)
+    a = BlochSphereRotation(qubit=q, axis=(1, 2, 3), angle=0.4)
+    b = BlochSphereRotation(qubit=q, axis=(1, 2, 3), angle=-0.3)
+    composed = compose_bloch_sphere_rotations(a, b)
+    assert composed == BlochSphereRotation(qubit=q, axis=(1, 2, 3), angle=0.1)
 
 
-if __name__ == "__main__":
-    unittest.main()
+def test_compose_bloch_sphere_rotations_different_axis() -> None:
+    # Visualizing this in 3D is difficult...
+    q = Qubit(123)
+    a = BlochSphereRotation(qubit=q, axis=(1, 0, 0), angle=math.pi / 2)
+    b = BlochSphereRotation(qubit=q, axis=(0, 0, 1), angle=-math.pi / 2)
+    c = BlochSphereRotation(qubit=q, axis=(0, 1, 0), angle=math.pi / 2)
+    composed = compose_bloch_sphere_rotations(a, compose_bloch_sphere_rotations(b, c))
+    assert composed == BlochSphereRotation(qubit=q, axis=(1, 1, 0), angle=math.pi)
+
+
+def test_single_gate() -> None:
+    register_manager = RegisterManager(qubit_register_size=2)
+    ir = IR()
+    ir.add_gate(Ry(Qubit(0), Float(1.2345)))
+    circuit = Circuit(register_manager, ir)
+
+    expected_ir = IR()
+    expected_ir.add_gate(Ry(Qubit(0), Float(1.2345)))
+    expected_circuit = Circuit(register_manager, expected_ir)
+
+    modify_circuit_and_check(circuit, general_merger.merge_single_qubit_gates, expected_circuit)
+
+    # Check that when no fusion happens, generator and arguments of gates are preserved.
+    assert ir.statements[0].generator == Ry
+    assert ir.statements[0].arguments == (Qubit(0), Float(1.2345))
+
+
+def test_two_hadamards() -> None:
+    register_manager = RegisterManager(qubit_register_size=4)
+    ir = IR()
+    ir.add_gate(H(Qubit(2)))
+    ir.add_gate(H(Qubit(2)))
+    circuit = Circuit(register_manager, ir)
+
+    expected_ir = IR()
+    expected_circuit = Circuit(register_manager, expected_ir)
+
+    modify_circuit_and_check(circuit, general_merger.merge_single_qubit_gates, expected_circuit)
+
+
+def test_two_hadamards_different_qubits() -> None:
+    register_manager = RegisterManager(qubit_register_size=4)
+    ir = IR()
+    ir.add_gate(H(Qubit(0)))
+    ir.add_gate(H(Qubit(2)))
+    circuit = Circuit(register_manager, ir)
+
+    expected_ir = IR()
+    expected_ir.add_gate(H(Qubit(0)))
+    expected_ir.add_gate(H(Qubit(2)))
+    expected_circuit = Circuit(register_manager, expected_ir)
+
+    modify_circuit_and_check(circuit, general_merger.merge_single_qubit_gates, expected_circuit)
+
+
+def test_merge_different_qubits() -> None:
+    register_manager = RegisterManager(qubit_register_size=4)
+    ir = IR()
+    ir.add_gate(Ry(Qubit(0), Float(math.pi / 2)))
+    ir.add_gate(Rx(Qubit(0), Float(math.pi)))
+    ir.add_gate(Rz(Qubit(1), Float(1.2345)))
+    ir.add_gate(Ry(Qubit(2), Float(1)))
+    ir.add_gate(Ry(Qubit(2), Float(3.234)))
+    circuit = Circuit(register_manager, ir)
+
+    expected_ir = IR()
+    expected_ir.add_gate(
+        BlochSphereRotation(qubit=Qubit(0), axis=(1, 0, 1), angle=math.pi)
+    )  # This is hadamard with 0 phase...
+    expected_ir.add_gate(Rz(Qubit(1), Float(1.2345)))
+    expected_ir.add_gate(Ry(Qubit(2), Float(4.234)))
+    expected_circuit = Circuit(register_manager, expected_ir)
+
+    modify_circuit_and_check(circuit, general_merger.merge_single_qubit_gates, expected_circuit)
+
+    assert ir.statements[0].is_anonymous  # When fusion happens, the resulting gate is anonymous.
+    assert ir.statements[1].generator == Rz  # Otherwise it keeps the same generator and arguments.
+    assert ir.statements[1].arguments == (Qubit(1), Float(1.2345))
+    assert ir.statements[2].is_anonymous
+
+
+def test_merge_and_flush() -> None:
+    register_manager = RegisterManager(qubit_register_size=4)
+    ir = IR()
+    ir.add_gate(Ry(Qubit(0), Float(math.pi / 2)))
+    ir.add_gate(Rz(Qubit(1), Float(1.5)))
+    ir.add_gate(Rx(Qubit(0), Float(math.pi)))
+    ir.add_gate(Rz(Qubit(1), Float(-2.5)))
+    ir.add_gate(CNOT(Qubit(0), Qubit(1)))
+    ir.add_gate(Ry(Qubit(0), Float(3.234)))
+    circuit = Circuit(register_manager, ir)
+
+    expected_ir = IR()
+    expected_ir.add_gate(
+        BlochSphereRotation(qubit=Qubit(0), axis=(1, 0, 1), angle=math.pi)
+    )  # This is hadamard with 0 phase...
+    expected_ir.add_gate(Rz(Qubit(1), Float(-1.0)))
+    expected_ir.add_gate(CNOT(Qubit(0), Qubit(1)))
+    expected_ir.add_gate(Ry(Qubit(0), Float(3.234)))
+    expected_circuit = Circuit(register_manager, expected_ir)
+
+    modify_circuit_and_check(circuit, general_merger.merge_single_qubit_gates, expected_circuit)
+
+    assert ir.statements[0].is_anonymous
+    assert ir.statements[3].generator == Ry
+    assert ir.statements[3].arguments, (Qubit(0), Float(3.234))

--- a/test/parser/libqasm/test_libqasm.py
+++ b/test/parser/libqasm/test_libqasm.py
@@ -1,16 +1,18 @@
-import unittest
+import pytest
 
-from opensquirrel.default_gates import *
+from opensquirrel.default_gates import CNOT, CR, CRk, H, I, Ry, X, default_gate_aliases, default_gate_set
+from opensquirrel.ir import Float, Int, Qubit
 from opensquirrel.parser.libqasm.parser import Parser
 
 
-class LibqasmTest(unittest.TestCase):
-    def setUp(self):
-        self.parser = Parser(gate_set=default_gate_set, gate_aliases=default_gate_aliases)
+@pytest.fixture(name="parser")
+def parser_fixture() -> Parser:
+    return Parser(gate_set=default_gate_set, gate_aliases=default_gate_aliases)
 
-    def test_simple(self):
-        circuit = self.parser.circuit_from_string(
-            """
+
+def test_simple(parser: Parser) -> None:
+    circuit = parser.circuit_from_string(
+        """
 version 3.0
 
 qubit[2] q
@@ -22,25 +24,23 @@ CNOT q[0], q[1]
 CR q[1], q[0], 5.123
 CRk q[0], q[1], 23
 """
-        )
+    )
 
-        self.assertEqual(circuit.qubit_register_size, 2)
-        self.assertEqual(circuit.qubit_register_name, "q")
-        self.assertEqual(
-            circuit.ir.statements,
-            [
-                H(Qubit(0)),
-                I(Qubit(0)),
-                Ry(Qubit(1), Float(1.234)),
-                CNOT(Qubit(0), Qubit(1)),
-                CR(Qubit(1), Qubit(0), Float(5.123)),
-                CRk(Qubit(0), Qubit(1), Int(23)),
-            ],
-        )
+    assert circuit.qubit_register_size == 2
+    assert circuit.qubit_register_name == "q"
+    assert circuit.ir.statements == [
+        H(Qubit(0)),
+        I(Qubit(0)),
+        Ry(Qubit(1), Float(1.234)),
+        CNOT(Qubit(0), Qubit(1)),
+        CR(Qubit(1), Qubit(0), Float(5.123)),
+        CRk(Qubit(0), Qubit(1), Int(23)),
+    ]
 
-    def test_sgmq(self):
-        circuit = self.parser.circuit_from_string(
-            """
+
+def test_sgmq(parser: Parser) -> None:
+    circuit = parser.circuit_from_string(
+        """
 version 3.0
 
 qubit[20] q
@@ -49,38 +49,37 @@ H q[5:9]
 X q[13,17]
 CRk q[0, 3], q[1, 4], 23
 """
-        )
+    )
 
-        self.assertEqual(circuit.qubit_register_size, 20)
-        self.assertEqual(circuit.qubit_register_name, "q")
-        self.assertEqual(
-            circuit.ir.statements,
-            [
-                H(Qubit(5)),
-                H(Qubit(6)),
-                H(Qubit(7)),
-                H(Qubit(8)),
-                H(Qubit(9)),
-                X(Qubit(13)),
-                X(Qubit(17)),
-                CRk(Qubit(0), Qubit(1), Int(23)),
-                CRk(Qubit(3), Qubit(4), Int(23)),
-            ],
-        )
+    assert circuit.qubit_register_size == 20
+    assert circuit.qubit_register_name == "q"
+    assert circuit.ir.statements == [
+        H(Qubit(5)),
+        H(Qubit(6)),
+        H(Qubit(7)),
+        H(Qubit(8)),
+        H(Qubit(9)),
+        X(Qubit(13)),
+        X(Qubit(17)),
+        CRk(Qubit(0), Qubit(1), Int(23)),
+        CRk(Qubit(3), Qubit(4), Int(23)),
+    ]
 
-    def test_error(self):
-        with self.assertRaisesRegex(Exception, "Error at <unknown file name>:1:30..31: failed to resolve variable 'q'"):
-            self.parser.circuit_from_string("""version 3.0; qubit[20] qu; H q[5]""")
 
-    def test_wrong_gate_argument_number_or_types(self):
-        with self.assertRaisesRegex(
-            Exception,
-            r"Parsing error: Error at <unknown file name>:1:26\.\.27: failed to resolve instruction 'H' with argument pack \(qubit, int\)",
-        ):
-            self.parser.circuit_from_string("""version 3.0; qubit[1] q; H q[0], 1""")
+def test_error(parser: Parser) -> None:
+    with pytest.raises(Exception, match="Error at <unknown file name>:1:30..31: failed to resolve variable 'q'"):
+        parser.circuit_from_string("version 3.0; qubit[20] qu; H q[5]")
 
-        with self.assertRaisesRegex(
-            Exception,
-            r"Parsing error: Error at <unknown file name>:1:26\.\.30: failed to resolve instruction 'CNOT' with argument pack \(qubit, int\)",
-        ):
-            self.parser.circuit_from_string("""version 3.0; qubit[1] q; CNOT q[0], 1""")
+
+def test_wrong_gate_argument_number_or_types(parser: Parser) -> None:
+    with pytest.raises(
+        Exception,
+        match=r"Parsing error: Error at <unknown file name>:1:26\.\.27: failed to resolve instruction 'H' with argument pack \(qubit, int\)",
+    ):
+        parser.circuit_from_string("version 3.0; qubit[1] q; H q[0], 1")
+
+    with pytest.raises(
+        Exception,
+        match=r"Parsing error: Error at <unknown file name>:1:26\.\.30: failed to resolve instruction 'CNOT' with argument pack \(qubit, int\)",
+    ):
+        parser.circuit_from_string("version 3.0; qubit[1] q; CNOT q[0], 1")

--- a/test/reindexer/test_qubit_reindexer.py
+++ b/test/reindexer/test_qubit_reindexer.py
@@ -1,5 +1,6 @@
+from __future__ import annotations
+
 import math
-from typing import List
 
 import numpy as np
 import pytest
@@ -11,74 +12,46 @@ from opensquirrel.register_manager import RegisterManager
 from opensquirrel.reindexer.qubit_reindexer import get_reindexed_circuit
 
 
-class TestReindexer:
-    @pytest.fixture
-    def replacement_gates_2(self) -> List[Gate]:
-        return [Y90(Qubit(1)), X(Qubit(3))]
+def circuit_1_reindexed() -> Circuit:
+    ir = IR()
+    ir.add_gate(Y90(Qubit(1)))
+    ir.add_gate(X(Qubit(0)))
+    return Circuit(RegisterManager(qubit_register_size=2), ir)
 
-    @pytest.fixture
-    def replacement_gates_4(self) -> List[Gate]:
-        return [
-            Measure(Qubit(1)),
-            BlochSphereRotation(Qubit(3), axis=(0, 0, 1), angle=math.pi),
-            MatrixGate(
-                np.array(
-                    [
-                        [1, 0, 0, 0],
-                        [0, 0, 1, 0],
-                        [0, 1, 0, 0],
-                        [0, 0, 0, 1],
-                    ]
-                ),
-                [Qubit(0), Qubit(3)],
-            ),
-            ControlledGate(Qubit(1), X(Qubit(2))),
-        ]
 
-    @pytest.fixture
-    def circuit_3_reindexed(self) -> Circuit:
-        ir = IR()
-        ir.add_gate(Y90(Qubit(1)))
-        ir.add_gate(X(Qubit(0)))
-        return Circuit(RegisterManager(qubit_register_size=2), ir)
+def replacement_gates_1() -> list[Gate]:
+    return [Y90(Qubit(1)), X(Qubit(3))]
 
-    @pytest.fixture
-    def circuit_4_reindexed(self) -> Circuit:
-        ir = IR()
-        ir.add_gate(Measure(Qubit(0)))
-        ir.add_gate(BlochSphereRotation(Qubit(2), axis=(0, 0, 1), angle=math.pi))
-        ir.add_gate(
-            MatrixGate(
-                np.array(
-                    [
-                        [1, 0, 0, 0],
-                        [0, 0, 1, 0],
-                        [0, 1, 0, 0],
-                        [0, 0, 0, 1],
-                    ]
-                ),
-                [Qubit(1), Qubit(2)],
-            )
-        )
-        ir.add_gate(ControlledGate(Qubit(0), X(Qubit(3))))
-        return Circuit(RegisterManager(qubit_register_size=4), ir)
 
-    @pytest.fixture
-    def qubit_indices_2(self) -> List[int]:
-        return [3, 1]
+def replacement_gates_2() -> list[Gate]:
+    return [
+        Measure(Qubit(1)),
+        BlochSphereRotation(Qubit(3), axis=(0, 0, 1), angle=math.pi),
+        MatrixGate(np.array([[1, 0, 0, 0], [0, 0, 1, 0], [0, 1, 0, 0], [0, 0, 0, 1]]), [Qubit(0), Qubit(3)]),
+        ControlledGate(Qubit(1), X(Qubit(2))),
+    ]
 
-    @pytest.fixture
-    def qubit_indices_4(self) -> List[int]:
-        return [1, 0, 3, 2]
 
-    def test_get_reindexed_circuit_3(
-        self, replacement_gates_2: List[Gate], qubit_indices_2: List[int], circuit_3_reindexed: Circuit
-    ) -> None:
-        circuit_3 = get_reindexed_circuit(replacement_gates_2, qubit_indices_2)
-        assert circuit_3 == circuit_3_reindexed
+def circuit_2_reindexed() -> Circuit:
+    ir = IR()
+    ir.add_gate(Measure(Qubit(0)))
+    ir.add_gate(BlochSphereRotation(Qubit(2), axis=(0, 0, 1), angle=math.pi))
+    matrix = np.array([[1, 0, 0, 0], [0, 0, 1, 0], [0, 1, 0, 0], [0, 0, 0, 1]])
+    ir.add_gate(MatrixGate(matrix, [Qubit(1), Qubit(2)]))
+    ir.add_gate(ControlledGate(Qubit(0), X(Qubit(3))))
+    return Circuit(RegisterManager(qubit_register_size=4), ir)
 
-    def test_get_reindexed_circuit_4(
-        self, replacement_gates_4: List[Gate], qubit_indices_4: List[int], circuit_4_reindexed: Circuit
-    ) -> None:
-        circuit_4 = get_reindexed_circuit(replacement_gates_4, qubit_indices_4)
-        assert circuit_4 == circuit_4_reindexed
+
+@pytest.mark.parametrize(
+    "replacement_gates, qubit_indices, circuit_reindexed",
+    [
+        (replacement_gates_1(), [3, 1], circuit_1_reindexed()),
+        (replacement_gates_2(), [1, 0, 3, 2], circuit_2_reindexed()),
+    ],
+    ids=["circuit1", "circuit2"],
+)
+def test_get_reindexed_circuit(
+    replacement_gates: list[Gate], qubit_indices: list[int], circuit_reindexed: Circuit
+) -> None:
+    circuit = get_reindexed_circuit(replacement_gates, qubit_indices)
+    assert circuit == circuit_reindexed

--- a/test/test_circuit_matrix_calculator.py
+++ b/test/test_circuit_matrix_calculator.py
@@ -1,195 +1,168 @@
-import unittest
+import math
+
+import numpy as np
 
 from opensquirrel import circuit_matrix_calculator
 from opensquirrel.circuit import Circuit
-from opensquirrel.default_gates import *
+from opensquirrel.default_gates import CNOT, H, X
 from opensquirrel.ir import IR, Qubit
 from opensquirrel.register_manager import RegisterManager
 
 
-class CircuitMatrixCalculatorTest(unittest.TestCase):
-    def test_hadamard(self):
-        register_manager = RegisterManager(qubit_register_size=1)
-        ir = IR()
-        ir.add_gate(H(Qubit(0)))
-        circuit = Circuit(register_manager, ir)
+def test_hadamard() -> None:
+    register_manager = RegisterManager(qubit_register_size=1)
+    ir = IR()
+    ir.add_gate(H(Qubit(0)))
+    circuit = Circuit(register_manager, ir)
 
-        self.assertTrue(
-            np.allclose(
-                circuit_matrix_calculator.get_circuit_matrix(circuit),
-                math.sqrt(0.5)
-                * np.array(
-                    [
-                        [1, 1],
-                        [1, -1],
-                    ]
-                ),
-            )
-        )
-
-    def test_double_hadamard(self):
-        register_manager = RegisterManager(qubit_register_size=1)
-        ir = IR()
-        ir.add_gate(H(Qubit(0)))
-        ir.add_gate(H(Qubit(0)))
-        circuit = Circuit(register_manager, ir)
-
-        self.assertTrue(np.allclose(circuit_matrix_calculator.get_circuit_matrix(circuit), np.eye(2)))
-
-    def test_triple_hadamard(self):
-        register_manager = RegisterManager(qubit_register_size=1)
-        ir = IR()
-        ir.add_gate(H(Qubit(0)))
-        ir.add_gate(H(Qubit(0)))
-        ir.add_gate(H(Qubit(0)))
-        circuit = Circuit(register_manager, ir)
-
-        self.assertTrue(
-            np.allclose(
-                circuit_matrix_calculator.get_circuit_matrix(circuit),
-                math.sqrt(0.5)
-                * np.array(
-                    [
-                        [1, 1],
-                        [1, -1],
-                    ]
-                ),
-            )
-        )
-
-    def test_hadamard_x(self):
-        register_manager = RegisterManager(qubit_register_size=2)
-        ir = IR()
-        ir.add_gate(H(Qubit(0)))
-        ir.add_gate(X(Qubit(1)))
-        circuit = Circuit(register_manager, ir)
-
-        self.assertTrue(
-            np.allclose(
-                circuit_matrix_calculator.get_circuit_matrix(circuit),
-                math.sqrt(0.5)
-                * np.array(
-                    [
-                        [0, 0, 1, 1],
-                        [0, 0, 1, -1],
-                        [1, 1, 0, 0],
-                        [1, -1, 0, 0],
-                    ]
-                ),
-            )
-        )
-
-    def test_x_hadamard(self):
-        register_manager = RegisterManager(qubit_register_size=2)
-        ir = IR()
-        ir.add_gate(H(Qubit(1)))
-        ir.add_gate(X(Qubit(0)))
-        circuit = Circuit(register_manager, ir)
-
-        self.assertTrue(
-            np.allclose(
-                circuit_matrix_calculator.get_circuit_matrix(circuit),
-                math.sqrt(0.5)
-                * np.array(
-                    [
-                        [0, 1, 0, 1],
-                        [1, 0, 1, 0],
-                        [0, 1, 0, -1],
-                        [1, 0, -1, 0],
-                    ]
-                ),
-            )
-        )
-
-    def test_cnot(self):
-        register_manager = RegisterManager(qubit_register_size=2)
-        ir = IR()
-        ir.add_gate(CNOT(Qubit(1), Qubit(0)))
-        circuit = Circuit(register_manager, ir)
-
-        self.assertTrue(
-            np.allclose(
-                circuit_matrix_calculator.get_circuit_matrix(circuit),
-                np.array(
-                    [
-                        [1, 0, 0, 0],
-                        [0, 1, 0, 0],
-                        [0, 0, 0, 1],
-                        [0, 0, 1, 0],
-                    ]
-                ),
-            )
-        )
-
-    def test_cnot_reversed(self):
-        register_manager = RegisterManager(qubit_register_size=2)
-        ir = IR()
-        ir.add_gate(CNOT(Qubit(0), Qubit(1)))
-        circuit = Circuit(register_manager, ir)
-
-        self.assertTrue(
-            np.allclose(
-                circuit_matrix_calculator.get_circuit_matrix(circuit),
-                np.array(
-                    [
-                        [1, 0, 0, 0],
-                        [0, 0, 0, 1],
-                        [0, 0, 1, 0],
-                        [0, 1, 0, 0],
-                    ]
-                ),
-            )
-        )
-
-    def test_hadamard_cnot(self):
-        register_manager = RegisterManager(qubit_register_size=2)
-        ir = IR()
-        ir.add_gate(H(Qubit(0)))
-        ir.add_gate(CNOT(Qubit(0), Qubit(1)))
-        circuit = Circuit(register_manager, ir)
-
-        self.assertTrue(
-            np.allclose(
-                circuit_matrix_calculator.get_circuit_matrix(circuit),
-                math.sqrt(0.5)
-                * np.array(
-                    [
-                        [1, 1, 0, 0],
-                        [0, 0, 1, -1],
-                        [0, 0, 1, 1],
-                        [1, -1, 0, 0],
-                    ]
-                ),
-            )
-        )
-
-    def test_hadamard_cnot_0_2(self):
-        register_manager = RegisterManager(qubit_register_size=3)
-        ir = IR()
-        ir.add_gate(H(Qubit(0)))
-        ir.add_gate(CNOT(Qubit(0), Qubit(2)))
-        circuit = Circuit(register_manager, ir)
-
-        print(circuit_matrix_calculator.get_circuit_matrix(circuit))
-        self.assertTrue(
-            np.allclose(
-                circuit_matrix_calculator.get_circuit_matrix(circuit),
-                math.sqrt(0.5)
-                * np.array(
-                    [
-                        [1, 1, 0, 0, 0, 0, 0, 0],
-                        [0, 0, 0, 0, 1, -1, 0, 0],
-                        [0, 0, 1, 1, 0, 0, 0, 0],
-                        [0, 0, 0, 0, 0, 0, 1, -1],
-                        [0, 0, 0, 0, 1, 1, 0, 0],
-                        [1, -1, 0, 0, 0, 0, 0, 0],
-                        [0, 0, 0, 0, 0, 0, 1, 1],
-                        [0, 0, 1, -1, 0, 0, 0, 0],
-                    ]
-                ),
-            )
-        )
+    np.testing.assert_almost_equal(
+        circuit_matrix_calculator.get_circuit_matrix(circuit), math.sqrt(0.5) * np.array([[1, 1], [1, -1]])
+    )
 
 
-if __name__ == "__main__":
-    unittest.main()
+def test_double_hadamard() -> None:
+    register_manager = RegisterManager(qubit_register_size=1)
+    ir = IR()
+    ir.add_gate(H(Qubit(0)))
+    ir.add_gate(H(Qubit(0)))
+    circuit = Circuit(register_manager, ir)
+
+    np.testing.assert_almost_equal(circuit_matrix_calculator.get_circuit_matrix(circuit), np.eye(2))
+
+
+def test_triple_hadamard() -> None:
+    register_manager = RegisterManager(qubit_register_size=1)
+    ir = IR()
+    ir.add_gate(H(Qubit(0)))
+    ir.add_gate(H(Qubit(0)))
+    ir.add_gate(H(Qubit(0)))
+    circuit = Circuit(register_manager, ir)
+
+    np.testing.assert_almost_equal(
+        circuit_matrix_calculator.get_circuit_matrix(circuit), math.sqrt(0.5) * np.array([[1, 1], [1, -1]])
+    )
+
+
+def test_hadamard_x() -> None:
+    register_manager = RegisterManager(qubit_register_size=2)
+    ir = IR()
+    ir.add_gate(H(Qubit(0)))
+    ir.add_gate(X(Qubit(1)))
+    circuit = Circuit(register_manager, ir)
+
+    np.testing.assert_almost_equal(
+        circuit_matrix_calculator.get_circuit_matrix(circuit),
+        math.sqrt(0.5)
+        * np.array(
+            [
+                [0, 0, 1, 1],
+                [0, 0, 1, -1],
+                [1, 1, 0, 0],
+                [1, -1, 0, 0],
+            ]
+        ),
+    )
+
+
+def test_x_hadamard() -> None:
+    register_manager = RegisterManager(qubit_register_size=2)
+    ir = IR()
+    ir.add_gate(H(Qubit(1)))
+    ir.add_gate(X(Qubit(0)))
+    circuit = Circuit(register_manager, ir)
+
+    np.testing.assert_almost_equal(
+        circuit_matrix_calculator.get_circuit_matrix(circuit),
+        math.sqrt(0.5)
+        * np.array(
+            [
+                [0, 1, 0, 1],
+                [1, 0, 1, 0],
+                [0, 1, 0, -1],
+                [1, 0, -1, 0],
+            ]
+        ),
+    )
+
+
+def test_cnot() -> None:
+    register_manager = RegisterManager(qubit_register_size=2)
+    ir = IR()
+    ir.add_gate(CNOT(Qubit(1), Qubit(0)))
+    circuit = Circuit(register_manager, ir)
+
+    np.testing.assert_almost_equal(
+        circuit_matrix_calculator.get_circuit_matrix(circuit),
+        [
+            [1, 0, 0, 0],
+            [0, 1, 0, 0],
+            [0, 0, 0, 1],
+            [0, 0, 1, 0],
+        ],
+    )
+
+
+def test_cnot_reversed() -> None:
+    register_manager = RegisterManager(qubit_register_size=2)
+    ir = IR()
+    ir.add_gate(CNOT(Qubit(0), Qubit(1)))
+    circuit = Circuit(register_manager, ir)
+
+    np.testing.assert_almost_equal(
+        circuit_matrix_calculator.get_circuit_matrix(circuit),
+        np.array(
+            [
+                [1, 0, 0, 0],
+                [0, 0, 0, 1],
+                [0, 0, 1, 0],
+                [0, 1, 0, 0],
+            ]
+        ),
+    )
+
+
+def test_hadamard_cnot() -> None:
+    register_manager = RegisterManager(qubit_register_size=2)
+    ir = IR()
+    ir.add_gate(H(Qubit(0)))
+    ir.add_gate(CNOT(Qubit(0), Qubit(1)))
+    circuit = Circuit(register_manager, ir)
+
+    np.testing.assert_almost_equal(
+        circuit_matrix_calculator.get_circuit_matrix(circuit),
+        math.sqrt(0.5)
+        * np.array(
+            [
+                [1, 1, 0, 0],
+                [0, 0, 1, -1],
+                [0, 0, 1, 1],
+                [1, -1, 0, 0],
+            ]
+        ),
+    )
+
+
+def test_hadamard_cnot_0_2() -> None:
+    register_manager = RegisterManager(qubit_register_size=3)
+    ir = IR()
+    ir.add_gate(H(Qubit(0)))
+    ir.add_gate(CNOT(Qubit(0), Qubit(2)))
+    circuit = Circuit(register_manager, ir)
+
+    print(circuit_matrix_calculator.get_circuit_matrix(circuit))
+    np.testing.assert_almost_equal(
+        circuit_matrix_calculator.get_circuit_matrix(circuit),
+        math.sqrt(0.5)
+        * np.array(
+            [
+                [1, 1, 0, 0, 0, 0, 0, 0],
+                [0, 0, 0, 0, 1, -1, 0, 0],
+                [0, 0, 1, 1, 0, 0, 0, 0],
+                [0, 0, 0, 0, 0, 0, 1, -1],
+                [0, 0, 0, 0, 1, 1, 0, 0],
+                [1, -1, 0, 0, 0, 0, 0, 0],
+                [0, 0, 0, 0, 0, 0, 1, 1],
+                [0, 0, 1, -1, 0, 0, 0, 0],
+            ]
+        ),
+    )

--- a/test/test_circuit_matrix_calculator.py
+++ b/test/test_circuit_matrix_calculator.py
@@ -52,15 +52,7 @@ def test_hadamard_x() -> None:
 
     np.testing.assert_almost_equal(
         circuit_matrix_calculator.get_circuit_matrix(circuit),
-        math.sqrt(0.5)
-        * np.array(
-            [
-                [0, 0, 1, 1],
-                [0, 0, 1, -1],
-                [1, 1, 0, 0],
-                [1, -1, 0, 0],
-            ]
-        ),
+        math.sqrt(0.5) * np.array([[0, 0, 1, 1], [0, 0, 1, -1], [1, 1, 0, 0], [1, -1, 0, 0]]),
     )
 
 
@@ -73,15 +65,7 @@ def test_x_hadamard() -> None:
 
     np.testing.assert_almost_equal(
         circuit_matrix_calculator.get_circuit_matrix(circuit),
-        math.sqrt(0.5)
-        * np.array(
-            [
-                [0, 1, 0, 1],
-                [1, 0, 1, 0],
-                [0, 1, 0, -1],
-                [1, 0, -1, 0],
-            ]
-        ),
+        math.sqrt(0.5) * np.array([[0, 1, 0, 1], [1, 0, 1, 0], [0, 1, 0, -1], [1, 0, -1, 0]]),
     )
 
 
@@ -92,13 +76,7 @@ def test_cnot() -> None:
     circuit = Circuit(register_manager, ir)
 
     np.testing.assert_almost_equal(
-        circuit_matrix_calculator.get_circuit_matrix(circuit),
-        [
-            [1, 0, 0, 0],
-            [0, 1, 0, 0],
-            [0, 0, 0, 1],
-            [0, 0, 1, 0],
-        ],
+        circuit_matrix_calculator.get_circuit_matrix(circuit), [[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 0, 1], [0, 0, 1, 0]]
     )
 
 
@@ -109,15 +87,7 @@ def test_cnot_reversed() -> None:
     circuit = Circuit(register_manager, ir)
 
     np.testing.assert_almost_equal(
-        circuit_matrix_calculator.get_circuit_matrix(circuit),
-        np.array(
-            [
-                [1, 0, 0, 0],
-                [0, 0, 0, 1],
-                [0, 0, 1, 0],
-                [0, 1, 0, 0],
-            ]
-        ),
+        circuit_matrix_calculator.get_circuit_matrix(circuit), [[1, 0, 0, 0], [0, 0, 0, 1], [0, 0, 1, 0], [0, 1, 0, 0]]
     )
 
 
@@ -130,15 +100,7 @@ def test_hadamard_cnot() -> None:
 
     np.testing.assert_almost_equal(
         circuit_matrix_calculator.get_circuit_matrix(circuit),
-        math.sqrt(0.5)
-        * np.array(
-            [
-                [1, 1, 0, 0],
-                [0, 0, 1, -1],
-                [0, 0, 1, 1],
-                [1, -1, 0, 0],
-            ]
-        ),
+        math.sqrt(0.5) * np.array([[1, 1, 0, 0], [0, 0, 1, -1], [0, 0, 1, 1], [1, -1, 0, 0]]),
     )
 
 
@@ -149,7 +111,6 @@ def test_hadamard_cnot_0_2() -> None:
     ir.add_gate(CNOT(Qubit(0), Qubit(2)))
     circuit = Circuit(register_manager, ir)
 
-    print(circuit_matrix_calculator.get_circuit_matrix(circuit))
     np.testing.assert_almost_equal(
         circuit_matrix_calculator.get_circuit_matrix(circuit),
         math.sqrt(0.5)

--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -1,56 +1,56 @@
 # This integration test also serves as example and code documentation.
 
 import importlib.util
-import unittest
+
+import pytest
 
 from opensquirrel.circuit import Circuit
 from opensquirrel.decomposer.cnot_decomposer import CNOTDecomposer
 from opensquirrel.decomposer.mckay_decomposer import McKayDecomposer
 from opensquirrel.decomposer.zyz_decomposer import ZYZDecomposer
-from opensquirrel.default_gates import *
+from opensquirrel.default_gates import CNOT, CZ, H
 from opensquirrel.exporter.export_format import ExportFormat
 
 
-class IntegrationTest(unittest.TestCase):
-    def test_simple(self):
-        circuit = Circuit.from_string(
-            """
-            version 3.0
+def test_simple() -> None:
+    circuit = Circuit.from_string(
+        """
+        version 3.0
 
-            qubit[3] q
+        qubit[3] q
 
-            Ry(1.23) q[0]
-            Ry(2.34) q[1]
-            CNOT q[0], q[1]
-            Rx(-2.3) q[0]
-            Ry(-3.14) q[1]
-            """
-        )
+        Ry(1.23) q[0]
+        Ry(2.34) q[1]
+        CNOT q[0], q[1]
+        Rx(-2.3) q[0]
+        Ry(-3.14) q[1]
+        """
+    )
 
-        #    Decompose CNOT as
-        #
-        #    -----•-----        ------- Z -------
-        #         |        ==           |
-        #    -----⊕----         --- H --•-- H ---
-        #
+    #    Decompose CNOT as
+    #
+    #    -----•-----        ------- Z -------
+    #         |        ==           |
+    #    -----⊕----         --- H --•-- H ---
+    #
 
-        circuit.replace(
-            CNOT,
-            lambda control, target: [
-                H(target),
-                CZ(control, target),
-                H(target),
-            ],
-        )
+    circuit.replace(
+        CNOT,
+        lambda control, target: [
+            H(target),
+            CZ(control, target),
+            H(target),
+        ],
+    )
 
-        # Do 1q-gate fusion and decomposer with McKay decomposition.
-        circuit.merge_single_qubit_gates()
-        circuit.decompose(decomposer=McKayDecomposer())
+    # Do 1q-gate fusion and decomposer with McKay decomposition.
+    circuit.merge_single_qubit_gates()
+    circuit.decompose(decomposer=McKayDecomposer())
 
-        # Write the transformed circuit as a cQASM v3 string.
-        self.assertEqual(
-            str(circuit),
-            """version 3.0
+    # Write the transformed circuit as a cQASM v3 string.
+    assert (
+        str(circuit)
+        == """version 3.0
 
 qubit[3] q
 
@@ -74,32 +74,33 @@ X90 q[1]
 Rz(1.5723889) q[1]
 X90 q[1]
 Rz(3.1415927) q[1]
-""",
-        )
+"""
+    )
 
-    def test_measurement(self):
-        circuit = Circuit.from_string(
-            """
-            version 3.0
 
-            qubit[3] q
-            bit[3] b
+def test_measurement() -> None:
+    circuit = Circuit.from_string(
+        """
+        version 3.0
 
-            Ry(2.34) q[2]
-            Rz(1.5707963) q[0]
-            Ry(-0.2) q[0]
-            CNOT q[1], q[0]
-            Rz(1.5789) q[0]
-            CNOT q[1], q[0]
-            Rz(2.5707963) q[1]
-            b[0, 2] = measure q[0, 2]
-            """,
-        )
-        circuit.merge_single_qubit_gates()
-        circuit.decompose(decomposer=McKayDecomposer())
-        self.assertEqual(
-            str(circuit),
-            """version 3.0
+        qubit[3] q
+        bit[3] b
+
+        Ry(2.34) q[2]
+        Rz(1.5707963) q[0]
+        Ry(-0.2) q[0]
+        CNOT q[1], q[0]
+        Rz(1.5789) q[0]
+        CNOT q[1], q[0]
+        Rz(2.5707963) q[1]
+        b[0, 2] = measure q[0, 2]
+        """,
+    )
+    circuit.merge_single_qubit_gates()
+    circuit.decompose(decomposer=McKayDecomposer())
+    assert (
+        str(circuit)
+        == """version 3.0
 
 qubit[3] q
 
@@ -118,67 +119,31 @@ Rz(0.80159265) q[2]
 X90 q[2]
 measure q[2]
 Rz(2.5707963) q[1]
-""",
-        )
+"""
+    )
 
-    def test_consecutive_measurements(self):
-        circuit = Circuit.from_string(
-            """
-            version 3.0
 
-            qubit[3] q
-            bit[3] b
+def test_consecutive_measurements() -> None:
+    circuit = Circuit.from_string(
+        """
+        version 3.0
 
-            H q[0]
-            H q[1]
-            H q[2]
-            b[0] = measure q[0]
-            b[1] = measure q[1]
-            b[2] = measure q[2]
-            """
-        )
-        circuit.merge_single_qubit_gates()
-        circuit.decompose(decomposer=McKayDecomposer())
-        self.assertEqual(
-            str(circuit),
-            """version 3.0
+        qubit[3] q
+        bit[3] b
 
-qubit[3] q
-
-X90 q[0]
-Rz(1.5707963) q[0]
-X90 q[0]
-measure q[0]
-X90 q[1]
-Rz(1.5707963) q[1]
-X90 q[1]
-measure q[1]
-X90 q[2]
-Rz(1.5707963) q[2]
-X90 q[2]
-measure q[2]
-""",
-        )
-
-    def test_measurements_unrolling(self):
-        circuit = Circuit.from_string(
-            """
-            version 3.0
-
-            qubit[3] q
-            bit[3] b
-
-            H q[0]
-            H q[1]
-            H q[2]
-            b = measure q
-            """
-        )
-        circuit.merge_single_qubit_gates()
-        circuit.decompose(decomposer=McKayDecomposer())
-        self.assertEqual(
-            str(circuit),
-            """version 3.0
+        H q[0]
+        H q[1]
+        H q[2]
+        b[0] = measure q[0]
+        b[1] = measure q[1]
+        b[2] = measure q[2]
+        """
+    )
+    circuit.merge_single_qubit_gates()
+    circuit.decompose(decomposer=McKayDecomposer())
+    assert (
+        str(circuit)
+        == """version 3.0
 
 qubit[3] q
 
@@ -194,27 +159,66 @@ X90 q[2]
 Rz(1.5707963) q[2]
 X90 q[2]
 measure q[2]
-""",
-        )
+"""
+    )
 
-    def test_measure_order(self):
-        circuit = Circuit.from_string(
-            """
-            version 3.0
 
-            qubit[2] q
-            bit[2] b
+def test_measurements_unrolling() -> None:
+    circuit = Circuit.from_string(
+        """
+        version 3.0
 
-            Rz(-2.3561945) q[1]
-            Rz(1.5707963) q[1]
-            b[1, 0] = measure q[1, 0]
-            """
-        )
-        circuit.merge_single_qubit_gates()
-        circuit.decompose(decomposer=McKayDecomposer())
-        self.assertEqual(
-            str(circuit),
-            """version 3.0
+        qubit[3] q
+        bit[3] b
+
+        H q[0]
+        H q[1]
+        H q[2]
+        b = measure q
+        """
+    )
+    circuit.merge_single_qubit_gates()
+    circuit.decompose(decomposer=McKayDecomposer())
+    assert (
+        str(circuit)
+        == """version 3.0
+
+qubit[3] q
+
+X90 q[0]
+Rz(1.5707963) q[0]
+X90 q[0]
+measure q[0]
+X90 q[1]
+Rz(1.5707963) q[1]
+X90 q[1]
+measure q[1]
+X90 q[2]
+Rz(1.5707963) q[2]
+X90 q[2]
+measure q[2]
+"""
+    )
+
+
+def test_measure_order() -> None:
+    circuit = Circuit.from_string(
+        """
+        version 3.0
+
+        qubit[2] q
+        bit[2] b
+
+        Rz(-2.3561945) q[1]
+        Rz(1.5707963) q[1]
+        b[1, 0] = measure q[1, 0]
+        """
+    )
+    circuit.merge_single_qubit_gates()
+    circuit.decompose(decomposer=McKayDecomposer())
+    assert (
+        str(circuit)
+        == """version 3.0
 
 qubit[2] q
 
@@ -225,32 +229,33 @@ X90 q[1]
 Rz(-0.3926991) q[1]
 measure q[1]
 measure q[0]
-""",
-        )
+"""
+    )
 
-    def test_multiple_qubit_bit_definitions_and_mid_circuit_measure_instructions(self):
-        circuit = Circuit.from_string(
-            """
-            version 3.0
 
-            qubit q0
-            bit b0
-            X q0
-            b0 = measure q0
+def test_multiple_qubit_bit_definitions_and_mid_circuit_measure_instructions() -> None:
+    circuit = Circuit.from_string(
+        """
+        version 3.0
 
-            qubit q1
-            bit b1
-            H q1
-            CNOT q1, q0
-            b1 = measure q1
-            b0 = measure q0
-            """
-        )
-        circuit.merge_single_qubit_gates()
-        circuit.decompose(decomposer=McKayDecomposer())
-        self.assertEqual(
-            str(circuit),
-            """version 3.0
+        qubit q0
+        bit b0
+        X q0
+        b0 = measure q0
+
+        qubit q1
+        bit b1
+        H q1
+        CNOT q1, q0
+        b1 = measure q1
+        b0 = measure q0
+        """
+    )
+    circuit.merge_single_qubit_gates()
+    circuit.decompose(decomposer=McKayDecomposer())
+    assert (
+        str(circuit)
+        == """version 3.0
 
 qubit[2] q
 
@@ -265,45 +270,46 @@ X90 q[1]
 CNOT q[1], q[0]
 measure q[1]
 measure q[0]
-""",
-        )
+"""
+    )
 
-    def test_qi(self):
-        circuit = Circuit.from_string(
-            """
-            version 3.0
 
-            // This is a single line comment which ends on the newline.
-            // The cQASM string must begin with the version instruction (apart from any preceding comments).
+def test_qi() -> None:
+    circuit = Circuit.from_string(
+        """
+        version 3.0
 
-            /* This is a multi-
-            line comment block */
+        // This is a single line comment which ends on the newline.
+        // The cQASM string must begin with the version instruction (apart from any preceding comments).
 
-            qubit[4] q
+        /* This is a multi-
+        line comment block */
 
-            // Let us create a Bell state on 2 qubits and a |+> state on the third qubit
+        qubit[4] q
 
-            H q[2]
-            H q[1]
-            H q[0]
-            Rz(1.5707963) q[0]
-            Ry(-0.2) q[0]
-            CNOT q[1], q[0]
-            Rz(1.5789) q[0]
-            CNOT q[1], q[0]
-            CNOT q[1], q[2]
-            Rz(2.5707963) q[1]
-            CR(2.123) q[2], q[3]
-            Ry(-1.5707963) q[1]
-            """
-        )
+        // Let us create a Bell state on 2 qubits and a |+> state on the third qubit
 
-        circuit.merge_single_qubit_gates()
-        circuit.decompose(decomposer=McKayDecomposer())
+        H q[2]
+        H q[1]
+        H q[0]
+        Rz(1.5707963) q[0]
+        Ry(-0.2) q[0]
+        CNOT q[1], q[0]
+        Rz(1.5789) q[0]
+        CNOT q[1], q[0]
+        CNOT q[1], q[2]
+        Rz(2.5707963) q[1]
+        CR(2.123) q[2], q[3]
+        Ry(-1.5707963) q[1]
+        """
+    )
 
-        self.assertEqual(
-            str(circuit),
-            """version 3.0
+    circuit.merge_single_qubit_gates()
+    circuit.decompose(decomposer=McKayDecomposer())
+
+    assert (
+        str(circuit)
+        == """version 3.0
 
 qubit[4] q
 
@@ -328,122 +334,118 @@ X90 q[1]
 Rz(1.5707963) q[1]
 X90 q[1]
 Rz(3.1415927) q[1]
-""",
-        )
+"""
+    )
 
-    def test_libqasm_error(self):
-        with self.assertRaisesRegex(
-            Exception,
-            r"Parsing error: Error at <unknown file name>:4:17\.\.19: failed to resolve instruction 'Ry' with argument pack \(qubit, float, int\)",
-        ):
-            Circuit.from_string(
-                """
+
+def test_libqasm_error() -> None:
+    with pytest.raises(
+        Exception,
+        match=r"Parsing error: Error at <unknown file name>:4:17\.\.19: failed to resolve instruction 'Ry' with argument pack \(qubit, float, int\)",
+    ):
+        Circuit.from_string(
+            """
                 version 3.0
                 qubit[3] q
                 Ry q[0], 1.23, 1
                 """,
-            )
-
-    def test_export_quantify_scheduler(self):
-        circuit = Circuit.from_string(
-            """
-            version 3.0
-
-            qubit[3] q
-            bit[3] b
-
-            H q[1]
-            CZ q[0], q[1]
-            CNOT q[0], q[1]
-            CRk(4) q[0], q[1]
-            H q[0]
-            b[0:1] = measure q[0:1]
-            """
         )
 
-        circuit.decompose(decomposer=CNOTDecomposer())
 
-        # Quantify-scheduler prefers CZ.
-        circuit.replace(
-            CNOT,
-            lambda control, target: [
-                H(target),
-                CZ(control, target),
-                H(target),
-            ],
-        )
+def test_export_quantify_scheduler() -> None:
+    circuit = Circuit.from_string(
+        """
+        version 3.0
 
-        # Reduce gate count by single-qubit gate fusion.
-        circuit.merge_single_qubit_gates()
+        qubit[3] q
+        bit[3] b
 
-        # FIXME: for best gate count we need a Z-XY decomposer.
-        # See https://github.com/QuTech-Delft/OpenSquirrel/issues/98
-        circuit.decompose(decomposer=ZYZDecomposer())
+        H q[1]
+        CZ q[0], q[1]
+        CNOT q[0], q[1]
+        CRk(4) q[0], q[1]
+        H q[0]
+        b[0:1] = measure q[0:1]
+        """
+    )
 
-        if importlib.util.find_spec("quantify_scheduler") is None:
-            with self.assertRaisesRegex(
-                Exception, "quantify-scheduler is not installed, or cannot be installed on " "your system"
-            ):
-                circuit.export(fmt=ExportFormat.QUANTIFY_SCHEDULER)
-        else:
-            exported_schedule = circuit.export(fmt=ExportFormat.QUANTIFY_SCHEDULER)
+    circuit.decompose(decomposer=CNOTDecomposer())
 
-            self.assertEqual(exported_schedule.name, "Exported OpenSquirrel circuit")
+    # Quantify-scheduler prefers CZ.
+    circuit.replace(
+        CNOT,
+        lambda control, target: [
+            H(target),
+            CZ(control, target),
+            H(target),
+        ],
+    )
 
-            operations = [
-                exported_schedule.operations[schedulable["operation_id"]].name
-                for schedulable in exported_schedule.schedulables.values()
-            ]
+    # Reduce gate count by single-qubit gate fusion.
+    circuit.merge_single_qubit_gates()
 
-            self.assertEqual(
-                operations,
-                [
-                    "Rz(-180, 'q[1]')",
-                    "Rxy(90, 90, 'q[1]')",
-                    "CZ (q[0], q[1])",
-                    "Rz(-180, 'q[1]')",
-                    "Rxy(90, 90, 'q[1]')",
-                    "CZ (q[0], q[1])",
-                    "Rz(90, 'q[1]')",
-                    "Rxy(11.25, 90, 'q[1]')",
-                    "Rz(-90, 'q[1]')",
-                    "CZ (q[0], q[1])",
-                    "Rz(90, 'q[1]')",
-                    "Rxy(-11.25, 90, 'q[1]')",
-                    "Rz(-90, 'q[1]')",
-                    "CZ (q[0], q[1])",
-                    "Rz(11.25, 'q[0]')",
-                    "Rxy(-90, 90, 'q[0]')",
-                    "Rz(-180, 'q[0]')",
-                    "Rz(-180, 'q[1]')",
-                    "Rxy(90, 90, 'q[1]')",
-                    "Measure q[0]",
-                    "Measure q[1]",
-                ],
-            )
+    # FIXME: for best gate count we need a Z-XY decomposer.
+    # See https://github.com/QuTech-Delft/OpenSquirrel/issues/98
+    circuit.decompose(decomposer=ZYZDecomposer())
 
-    def test_merge_y90_x_to_h(self):
-        circuit = Circuit.from_string(
-            """
-            version 3.0
+    if importlib.util.find_spec("quantify_scheduler") is None:
+        with pytest.raises(
+            Exception, match="quantify-scheduler is not installed, or cannot be installed on " "your system"
+        ):
+            circuit.export(fmt=ExportFormat.QUANTIFY_SCHEDULER)
+    else:
+        exported_schedule = circuit.export(fmt=ExportFormat.QUANTIFY_SCHEDULER)
 
-            qubit q
+        assert exported_schedule.name == "Exported OpenSquirrel circuit"
 
-            Y90 q
-            X q
-            """
-        )
-        circuit.merge_single_qubit_gates()
-        self.assertEqual(
-            str(circuit),
-            """version 3.0
+        operations = [
+            exported_schedule.operations[schedulable["operation_id"]].name
+            for schedulable in exported_schedule.schedulables.values()
+        ]
+
+        assert operations == [
+            "Rz(-180, 'q[1]')",
+            "Rxy(90, 90, 'q[1]')",
+            "CZ (q[0], q[1])",
+            "Rz(-180, 'q[1]')",
+            "Rxy(90, 90, 'q[1]')",
+            "CZ (q[0], q[1])",
+            "Rz(90, 'q[1]')",
+            "Rxy(11.25, 90, 'q[1]')",
+            "Rz(-90, 'q[1]')",
+            "CZ (q[0], q[1])",
+            "Rz(90, 'q[1]')",
+            "Rxy(-11.25, 90, 'q[1]')",
+            "Rz(-90, 'q[1]')",
+            "CZ (q[0], q[1])",
+            "Rz(11.25, 'q[0]')",
+            "Rxy(-90, 90, 'q[0]')",
+            "Rz(-180, 'q[0]')",
+            "Rz(-180, 'q[1]')",
+            "Rxy(90, 90, 'q[1]')",
+            "Measure q[0]",
+            "Measure q[1]",
+        ]
+
+
+def test_merge_y90_x_to_h() -> None:
+    circuit = Circuit.from_string(
+        """
+        version 3.0
+
+        qubit q
+
+        Y90 q
+        X q
+        """
+    )
+    circuit.merge_single_qubit_gates()
+    assert (
+        str(circuit)
+        == """version 3.0
 
 qubit[1] q
 
 H q[0]
-""",
-        )
-
-
-if __name__ == "__main__":
-    unittest.main()
+"""
+    )

--- a/test/test_ir.py
+++ b/test/test_ir.py
@@ -4,7 +4,6 @@ import math
 
 import numpy as np
 import pytest
-from numpy.typing import NDArray
 
 from opensquirrel.common import ATOL
 from opensquirrel.ir import BlochSphereRotation, ControlledGate, MatrixGate, Measure, Qubit

--- a/test/test_replacer.py
+++ b/test/test_replacer.py
@@ -1,52 +1,58 @@
 from __future__ import annotations
 
-import unittest
+import math
+
+import pytest
 
 from opensquirrel.circuit import Circuit
 from opensquirrel.decomposer import general_decomposer
 from opensquirrel.decomposer.general_decomposer import Decomposer, check_gate_replacement
-from opensquirrel.default_gates import *
-from opensquirrel.ir import IR, Comment, Qubit
+from opensquirrel.default_gates import CNOT, Y90, BlochSphereRotation, H, I, Ry, Rz, X, Z, sqrtSWAP
+from opensquirrel.ir import IR, Comment, Float, Gate, Qubit
 from opensquirrel.register_manager import RegisterManager
 
 
-class ReplacerTest(unittest.TestCase):
-    @staticmethod
-    def test_check_valid_replacement():
-        check_gate_replacement(BlochSphereRotation.identity(Qubit(0)), [BlochSphereRotation.identity(Qubit(0))])
+class TestCheckGateReplacement:
 
-        check_gate_replacement(
-            BlochSphereRotation.identity(Qubit(0)),
-            [BlochSphereRotation.identity(Qubit(0)), BlochSphereRotation.identity(Qubit(0))],
-        )
+    @pytest.mark.parametrize(
+        "gate, replacement_gates",
+        [
+            (I(Qubit(0)), [I(Qubit(0))]),
+            (I(Qubit(0)), [I(Qubit(0)), I(Qubit(0))]),
+            (I(Qubit(0)), [H(Qubit(0)), H(Qubit(0))]),
+            (H(Qubit(0)), [H(Qubit(0)), H(Qubit(0)), H(Qubit(0))]),
+            (CNOT(Qubit(0), Qubit(1)), [CNOT(Qubit(0), Qubit(1)), I(Qubit(0))]),
+            # Arbitrary global phase change is not considered an issue.
+            (
+                CNOT(Qubit(0), Qubit(1)),
+                [CNOT(Qubit(0), Qubit(1)), BlochSphereRotation(Qubit(0), angle=0, axis=(1, 0, 0), phase=621.6546)],
+            ),
+        ],
+    )
+    def test_valid_replacement(self, gate: Gate, replacement_gates: list[Gate]) -> None:
+        check_gate_replacement(gate, replacement_gates)
 
-        check_gate_replacement(BlochSphereRotation.identity(Qubit(0)), [H(Qubit(0)), H(Qubit(0))])
+    @pytest.mark.parametrize(
+        "gate, replacement_gates, error_msg",
+        [
+            (H(Qubit(0)), [H(Qubit(1))], "Replacement for gate H does not seem to operate on the right qubits"),
+            (
+                CNOT(Qubit(0), Qubit(1)),
+                [CNOT(Qubit(2), Qubit(1))],
+                "Replacement for gate CNOT does not seem to operate on the right qubits",
+            ),
+            (
+                CNOT(Qubit(0), Qubit(1)),
+                [CNOT(Qubit(1), Qubit(0))],
+                "Replacement for gate CNOT does not preserve the quantum state",
+            ),
+        ],
+    )
+    def test_wrong_qubit(self, gate: Gate, replacement_gates: list[Gate], error_msg: str) -> None:
+        with pytest.raises(Exception, match=error_msg):
+            check_gate_replacement(gate, replacement_gates)
 
-        check_gate_replacement(H(Qubit(0)), [H(Qubit(0)), H(Qubit(0)), H(Qubit(0))])
-
-        check_gate_replacement(
-            CNOT(Qubit(0), Qubit(1)), [CNOT(Qubit(0), Qubit(1)), BlochSphereRotation.identity(Qubit(0))]
-        )
-
-        # Arbitrary global phase change is not considered an issue.
-        check_gate_replacement(
-            CNOT(Qubit(0), Qubit(1)),
-            [CNOT(Qubit(0), Qubit(1)), BlochSphereRotation(Qubit(0), angle=0, axis=(1, 0, 0), phase=621.6546)],
-        )
-
-    def test_check_valid_replacement_wrong_qubit(self):
-        with self.assertRaisesRegex(Exception, r"Replacement for gate H does not seem to operate on the right qubits"):
-            check_gate_replacement(H(Qubit(0)), [H(Qubit(1))])
-
-        with self.assertRaisesRegex(
-            Exception, r"Replacement for gate CNOT does not seem to operate on the right qubits"
-        ):
-            check_gate_replacement(CNOT(Qubit(0), Qubit(1)), [CNOT(Qubit(2), Qubit(1))])
-
-        with self.assertRaisesRegex(Exception, r"Replacement for gate CNOT does not preserve the quantum state"):
-            check_gate_replacement(CNOT(Qubit(0), Qubit(1)), [CNOT(Qubit(1), Qubit(0))])
-
-    def test_check_valid_replacement_cnot_as_sqrt_swap(self):
+    def test_cnot_as_sqrt_swap(self):
         # https://en.wikipedia.org/wiki/Quantum_logic_gate#/media/File:Qcircuit_CNOTsqrtSWAP2.svg
         c = Qubit(0)
         t = Qubit(1)
@@ -63,7 +69,7 @@ class ReplacerTest(unittest.TestCase):
             ],
         )
 
-        with self.assertRaisesRegex(Exception, r"Replacement for gate CNOT does not preserve the quantum state"):
+        with pytest.raises(Exception, match="Replacement for gate CNOT does not preserve the quantum state"):
             check_gate_replacement(
                 CNOT(control=c, target=t),
                 [
@@ -77,9 +83,7 @@ class ReplacerTest(unittest.TestCase):
                 ],
             )
 
-        with self.assertRaisesRegex(
-            Exception, r"Replacement for gate CNOT does not seem to operate on the right qubits"
-        ):
+        with pytest.raises(Exception, match="Replacement for gate CNOT does not seem to operate on the right qubits"):
             check_gate_replacement(
                 CNOT(control=c, target=t),
                 [
@@ -93,16 +97,18 @@ class ReplacerTest(unittest.TestCase):
                 ],
             )
 
-    def test_check_valid_replacement_large_number_of_qubits(self):
+    def test_large_number_of_qubits(self):
         # If we were building the whole circuit matrix, this would run out of memory.
         check_gate_replacement(H(Qubit(9234687)), [Y90(Qubit(9234687)), X(Qubit(9234687))])
 
-        with self.assertRaisesRegex(Exception, r"Replacement for gate H does not seem to operate on the right qubits"):
+        with pytest.raises(Exception, match="Replacement for gate H does not seem to operate on the right qubits"):
             check_gate_replacement(H(Qubit(9234687)), [Y90(Qubit(698446519)), X(Qubit(9234687))])
 
-        with self.assertRaisesRegex(Exception, r"Replacement for gate H does not preserve the quantum state"):
+        with pytest.raises(Exception, match="Replacement for gate H does not preserve the quantum state"):
             check_gate_replacement(H(Qubit(9234687)), [Y90(Qubit(9234687)), X(Qubit(9234687)), X(Qubit(9234687))])
 
+
+class TestReplacer:
     def test_replace_generic(self):
         register_manager = RegisterManager(qubit_register_size=3)
         ir = IR()
@@ -126,7 +132,7 @@ class ReplacerTest(unittest.TestCase):
         expected_ir.add_gate(CNOT(Qubit(0), Qubit(1)))
         expected_circuit = Circuit(register_manager, expected_ir)
 
-        self.assertEqual(expected_circuit, circuit)
+        assert expected_circuit == circuit
 
     def test_replace(self):
         register_manager = RegisterManager(qubit_register_size=3)
@@ -143,8 +149,4 @@ class ReplacerTest(unittest.TestCase):
         expected_ir.add_comment(Comment("Test comment."))
         expected_circuit = Circuit(register_manager, expected_ir)
 
-        self.assertEqual(expected_circuit, circuit)
-
-
-if __name__ == "__main__":
-    unittest.main()
+        assert expected_circuit == circuit

--- a/test/test_writer.py
+++ b/test/test_writer.py
@@ -1,73 +1,72 @@
-import unittest
-
 from opensquirrel.circuit import Circuit
-from opensquirrel.default_gates import *
+from opensquirrel.default_gates import CR, H
 from opensquirrel.exporter import writer
-from opensquirrel.ir import IR, Comment, Float, Qubit
+from opensquirrel.ir import IR, BlochSphereRotation, Comment, Float, Qubit
 from opensquirrel.register_manager import RegisterManager
 
 
-class WriterTest(unittest.TestCase):
-    def test_write(self):
-        register_manager = RegisterManager(qubit_register_size=3)
-        ir = IR()
-        circuit = Circuit(register_manager, ir)
+def test_write() -> None:
+    register_manager = RegisterManager(qubit_register_size=3)
+    ir = IR()
+    circuit = Circuit(register_manager, ir)
 
-        self.assertEqual(
-            writer.circuit_to_string(circuit),
-            """version 3.0
+    assert (
+        writer.circuit_to_string(circuit)
+        == """version 3.0
 
 qubit[3] q
 
-""",
-        )
+"""
+    )
 
-        ir.add_gate(H(Qubit(0)))
-        ir.add_gate(CR(Qubit(0), Qubit(1), Float(1.234)))
-        circuit = Circuit(register_manager, ir)
+    ir.add_gate(H(Qubit(0)))
+    ir.add_gate(CR(Qubit(0), Qubit(1), Float(1.234)))
+    circuit = Circuit(register_manager, ir)
 
-        self.assertEqual(
-            writer.circuit_to_string(circuit),
-            """version 3.0
+    assert (
+        writer.circuit_to_string(circuit)
+        == """version 3.0
 
 qubit[3] q
 
 H q[0]
 CR(1.234) q[0], q[1]
-""",
-        )
+"""
+    )
 
-    def test_anonymous_gate(self):
-        register_manager = RegisterManager(qubit_register_size=2)
-        ir = IR()
-        ir.add_gate(CR(Qubit(0), Qubit(1), Float(1.234)))
-        ir.add_gate(BlochSphereRotation(Qubit(0), axis=(1, 1, 1), angle=1.23))
-        ir.add_gate(CR(Qubit(0), Qubit(1), Float(1.234)))
-        circuit = Circuit(register_manager, ir)
 
-        self.assertEqual(
-            writer.circuit_to_string(circuit),
-            """version 3.0
+def test_anonymous_gate() -> None:
+    register_manager = RegisterManager(qubit_register_size=2)
+    ir = IR()
+    ir.add_gate(CR(Qubit(0), Qubit(1), Float(1.234)))
+    ir.add_gate(BlochSphereRotation(Qubit(0), axis=(1, 1, 1), angle=1.23))
+    ir.add_gate(CR(Qubit(0), Qubit(1), Float(1.234)))
+    circuit = Circuit(register_manager, ir)
+
+    assert (
+        writer.circuit_to_string(circuit)
+        == """version 3.0
 
 qubit[2] q
 
 CR(1.234) q[0], q[1]
 <anonymous-gate>
 CR(1.234) q[0], q[1]
-""",
-        )
+"""
+    )
 
-    def test_comment(self):
-        register_manager = RegisterManager(qubit_register_size=3)
-        ir = IR()
-        ir.add_gate(H(Qubit(0)))
-        ir.add_comment(Comment("My comment"))
-        ir.add_gate(CR(Qubit(0), Qubit(1), Float(1.234)))
-        circuit = Circuit(register_manager, ir)
 
-        self.assertEqual(
-            writer.circuit_to_string(circuit),
-            """version 3.0
+def test_comment() -> None:
+    register_manager = RegisterManager(qubit_register_size=3)
+    ir = IR()
+    ir.add_gate(H(Qubit(0)))
+    ir.add_comment(Comment("My comment"))
+    ir.add_gate(CR(Qubit(0), Qubit(1), Float(1.234)))
+    circuit = Circuit(register_manager, ir)
+
+    assert (
+        writer.circuit_to_string(circuit)
+        == """version 3.0
 
 qubit[3] q
 
@@ -76,25 +75,22 @@ H q[0]
 /* My comment */
 
 CR(1.234) q[0], q[1]
-""",
-        )
+"""
+    )
 
-    def test_cap_significant_digits(self):
-        register_manager = RegisterManager(qubit_register_size=3)
-        ir = IR()
-        ir.add_gate(CR(Qubit(0), Qubit(1), Float(1.6546514861321684321654)))
-        circuit = Circuit(register_manager, ir)
 
-        self.assertEqual(
-            writer.circuit_to_string(circuit),
-            """version 3.0
+def test_cap_significant_digits() -> None:
+    register_manager = RegisterManager(qubit_register_size=3)
+    ir = IR()
+    ir.add_gate(CR(Qubit(0), Qubit(1), Float(1.6546514861321684321654)))
+    circuit = Circuit(register_manager, ir)
+
+    assert (
+        writer.circuit_to_string(circuit)
+        == """version 3.0
 
 qubit[3] q
 
 CR(1.6546515) q[0], q[1]
-""",
-        )
-
-
-if __name__ == "__main__":
-    unittest.main()
+"""
+    )

--- a/test/test_zyz_decomposer.py
+++ b/test/test_zyz_decomposer.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import math
 
 import pytest

--- a/test/test_zyz_decomposer.py
+++ b/test/test_zyz_decomposer.py
@@ -1,58 +1,40 @@
 import math
 
+import pytest
+
 from opensquirrel.decomposer.zyz_decomposer import ZYZDecomposer
-from opensquirrel.default_gates import CNOT, CR, H, Rx, Ry, Rz, S, Sdag, X, Y, Z
-from opensquirrel.ir import BlochSphereRotation, Float, Qubit
+from opensquirrel.default_gates import CNOT, CR, H, I, Rx, Ry, Rz, S, Sdag, X, Y, Z
+from opensquirrel.ir import BlochSphereRotation, Float, Gate, Qubit
 
 
-def test_ignores_2q_gates() -> None:
-    ZYZDecomposer().decompose(CNOT(Qubit(0), Qubit(1))) == [CNOT(Qubit(0), Qubit(1))]
-    assert ZYZDecomposer().decompose(CR(Qubit(2), Qubit(3), Float(2.123))) == [CR(Qubit(2), Qubit(3), Float(2.123))]
+@pytest.fixture(name="decomposer")
+def decomposer_fixture() -> ZYZDecomposer:
+    return ZYZDecomposer()
 
 
-def test_identity_empty_decomposition() -> None:
-    assert ZYZDecomposer().decompose(BlochSphereRotation.identity(Qubit(0))) == []
-
-
-def test_x() -> None:
-    assert ZYZDecomposer().decompose(X(Qubit(0))) == [
-        S(Qubit(0)),
-        Ry(Qubit(0), Float(math.pi)),
-        Sdag(Qubit(0)),
-    ]
-
-
-def test_x_arbitrary() -> None:
-    assert ZYZDecomposer().decompose(Rx(Qubit(0), Float(0.9))) == [
-        S(Qubit(0)),
-        Ry(Qubit(0), Float(0.9)),
-        Sdag(Qubit(0)),
-    ]
-
-
-def test_y() -> None:
-    assert ZYZDecomposer().decompose(Y(Qubit(0))) == [Ry(Qubit(0), Float(math.pi))]
-
-
-def test_y_arbitrary() -> None:
-    assert ZYZDecomposer().decompose(Ry(Qubit(0), Float(0.9))) == [Ry(Qubit(0), Float(0.9))]
-
-
-def test_z() -> None:
-    assert ZYZDecomposer().decompose(Z(Qubit(0))) == [Rz(Qubit(0), Float(math.pi))]
-
-
-def test_z_arbitrary() -> None:
-    assert ZYZDecomposer().decompose(Rz(Qubit(0), Float(0.123))) == [Rz(Qubit(0), Float(0.123))]
-
-
-def test_hadamard() -> None:
-    assert ZYZDecomposer().decompose(H(Qubit(0))) == [Rz(Qubit(0), Float(math.pi)), Ry(Qubit(0), Float(math.pi / 2))]
-
-
-def test_arbitrary() -> None:
-    assert ZYZDecomposer().decompose(BlochSphereRotation(qubit=Qubit(0), angle=5.21, axis=(1, 2, 3), phase=0.324)) == [
-        Rz(Qubit(0), Float(0.018644578210710527)),
-        Ry(Qubit(0), Float(-0.6209410696845807)),
-        Rz(Qubit(0), Float(-0.9086506397909061)),
-    ]
+@pytest.mark.parametrize(
+    "gate, expected_result",
+    [
+        (CNOT(Qubit(0), Qubit(1)), [CNOT(Qubit(0), Qubit(1))]),
+        (CR(Qubit(2), Qubit(3), Float(2.123)), [CR(Qubit(2), Qubit(3), Float(2.123))]),
+        (I(Qubit(0)), []),
+        (X(Qubit(0)), [S(Qubit(0)), Ry(Qubit(0), Float(math.pi)), Sdag(Qubit(0))]),
+        (Rx(Qubit(0), Float(0.9)), [S(Qubit(0)), Ry(Qubit(0), Float(0.9)), Sdag(Qubit(0))]),
+        (Y(Qubit(0)), [Ry(Qubit(0), Float(math.pi))]),
+        (Ry(Qubit(0), Float(0.9)), [Ry(Qubit(0), Float(0.9))]),
+        (Z(Qubit(0)), [Rz(Qubit(0), Float(math.pi))]),
+        (Rz(Qubit(0), Float(0.123)), [Rz(Qubit(0), Float(0.123))]),
+        (H(Qubit(0)), [Rz(Qubit(0), Float(math.pi)), Ry(Qubit(0), Float(math.pi / 2))]),
+        (
+            BlochSphereRotation(qubit=Qubit(0), angle=5.21, axis=(1, 2, 3), phase=0.324),
+            [
+                Rz(Qubit(0), Float(0.018644578210710527)),
+                Ry(Qubit(0), Float(-0.6209410696845807)),
+                Rz(Qubit(0), Float(-0.9086506397909061)),
+            ],
+        ),
+    ],
+    ids=["CNOT", "CR", "I", "X", "Rx", "Y", "Ry", "Z", "Rz", "H", "arbitrary"],
+)
+def test_zyz_decomposer(decomposer: ZYZDecomposer, gate: Gate, expected_result: list[Gate]) -> None:
+    assert decomposer.decompose(gate) == expected_result

--- a/test/test_zyz_decomposer.py
+++ b/test/test_zyz_decomposer.py
@@ -1,92 +1,58 @@
-import unittest
-from test.ir_equality_test_base import IREqualityTestBase
+import math
 
 from opensquirrel.decomposer.zyz_decomposer import ZYZDecomposer
-from opensquirrel.default_gates import *
-from opensquirrel.ir import Float, Qubit
+from opensquirrel.default_gates import CNOT, CR, H, Rx, Ry, Rz, S, Sdag, X, Y, Z
+from opensquirrel.ir import BlochSphereRotation, Float, Qubit
 
 
-class ZYZDecomposerTest(IREqualityTestBase):
-    def test_ignores_2q_gates(self):
-        self.assertEqual(ZYZDecomposer().decompose(CNOT(Qubit(0), Qubit(1))), [CNOT(Qubit(0), Qubit(1))])
-        self.assertEqual(
-            ZYZDecomposer().decompose(CR(Qubit(2), Qubit(3), Float(2.123))), [CR(Qubit(2), Qubit(3), Float(2.123))]
-        )
-
-    def test_identity_empty_decomposition(self):
-        self.assertEqual(ZYZDecomposer().decompose(BlochSphereRotation.identity(Qubit(0))), [])
-
-    def test_x(self):
-        self.assertEqual(
-            ZYZDecomposer().decompose(X(Qubit(0))),
-            [
-                S(Qubit(0)),
-                Ry(Qubit(0), Float(math.pi)),
-                Sdag(Qubit(0)),
-            ],
-        )
-
-    def test_x_arbitrary(self):
-        self.assertEqual(
-            ZYZDecomposer().decompose(Rx(Qubit(0), Float(0.9))),
-            [
-                S(Qubit(0)),
-                Ry(Qubit(0), Float(0.9)),
-                Sdag(Qubit(0)),
-            ],
-        )
-
-    def test_y(self):
-        self.assertEqual(
-            ZYZDecomposer().decompose(Y(Qubit(0))),
-            [
-                Ry(Qubit(0), Float(math.pi)),
-            ],
-        )
-
-    def test_y_arbitrary(self):
-        self.assertEqual(
-            ZYZDecomposer().decompose(Ry(Qubit(0), Float(0.9))),
-            [
-                Ry(Qubit(0), Float(0.9)),
-            ],
-        )
-
-    def test_z(self):
-        self.assertEqual(
-            ZYZDecomposer().decompose(Z(Qubit(0))),
-            [
-                Rz(Qubit(0), Float(math.pi)),
-            ],
-        )
-
-    def test_z_arbitrary(self):
-        self.assertEqual(
-            ZYZDecomposer().decompose(Rz(Qubit(0), Float(0.123))),
-            [
-                Rz(Qubit(0), Float(0.123)),
-            ],
-        )
-
-    def test_hadamard(self):
-        self.assertEqual(
-            ZYZDecomposer().decompose(H(Qubit(0))),
-            [
-                Rz(Qubit(0), Float(math.pi)),
-                Ry(Qubit(0), Float(math.pi / 2)),
-            ],
-        )
-
-    def test_arbitrary(self):
-        self.assertEqual(
-            ZYZDecomposer().decompose(BlochSphereRotation(qubit=Qubit(0), angle=5.21, axis=(1, 2, 3), phase=0.324)),
-            [
-                Rz(Qubit(0), Float(0.018644578210710527)),
-                Ry(Qubit(0), Float(-0.6209410696845807)),
-                Rz(Qubit(0), Float(-0.9086506397909061)),
-            ],
-        )
+def test_ignores_2q_gates() -> None:
+    ZYZDecomposer().decompose(CNOT(Qubit(0), Qubit(1))) == [CNOT(Qubit(0), Qubit(1))]
+    assert ZYZDecomposer().decompose(CR(Qubit(2), Qubit(3), Float(2.123))) == [CR(Qubit(2), Qubit(3), Float(2.123))]
 
 
-if __name__ == "__main__":
-    unittest.main()
+def test_identity_empty_decomposition() -> None:
+    assert ZYZDecomposer().decompose(BlochSphereRotation.identity(Qubit(0))) == []
+
+
+def test_x() -> None:
+    assert ZYZDecomposer().decompose(X(Qubit(0))) == [
+        S(Qubit(0)),
+        Ry(Qubit(0), Float(math.pi)),
+        Sdag(Qubit(0)),
+    ]
+
+
+def test_x_arbitrary() -> None:
+    assert ZYZDecomposer().decompose(Rx(Qubit(0), Float(0.9))) == [
+        S(Qubit(0)),
+        Ry(Qubit(0), Float(0.9)),
+        Sdag(Qubit(0)),
+    ]
+
+
+def test_y() -> None:
+    assert ZYZDecomposer().decompose(Y(Qubit(0))) == [Ry(Qubit(0), Float(math.pi))]
+
+
+def test_y_arbitrary() -> None:
+    assert ZYZDecomposer().decompose(Ry(Qubit(0), Float(0.9))) == [Ry(Qubit(0), Float(0.9))]
+
+
+def test_z() -> None:
+    assert ZYZDecomposer().decompose(Z(Qubit(0))) == [Rz(Qubit(0), Float(math.pi))]
+
+
+def test_z_arbitrary() -> None:
+    assert ZYZDecomposer().decompose(Rz(Qubit(0), Float(0.123))) == [Rz(Qubit(0), Float(0.123))]
+
+
+def test_hadamard() -> None:
+    assert ZYZDecomposer().decompose(H(Qubit(0))) == [Rz(Qubit(0), Float(math.pi)), Ry(Qubit(0), Float(math.pi / 2))]
+
+
+def test_arbitrary() -> None:
+    assert ZYZDecomposer().decompose(BlochSphereRotation(qubit=Qubit(0), angle=5.21, axis=(1, 2, 3), phase=0.324)) == [
+        Rz(Qubit(0), Float(0.018644578210710527)),
+        Ry(Qubit(0), Float(-0.6209410696845807)),
+        Rz(Qubit(0), Float(-0.9086506397909061)),
+    ]

--- a/test/utils/test_matrix_expander.py
+++ b/test/utils/test_matrix_expander.py
@@ -1,5 +1,4 @@
 import math
-import unittest
 
 import numpy as np
 
@@ -7,71 +6,60 @@ from opensquirrel.ir import BlochSphereRotation, ControlledGate, MatrixGate, Qub
 from opensquirrel.utils import matrix_expander
 
 
-class MatrixExpanderTest(unittest.TestCase):
-    def test_bloch_sphere_rotation(self):
-        gate = BlochSphereRotation(qubit=Qubit(0), axis=(0.8, -0.3, 1.5), angle=0.9468, phase=2.533)
-        self.assertTrue(
-            np.allclose(
-                matrix_expander.get_matrix(gate, 2),
-                np.array(
-                    [
-                        [-0.50373461 + 0.83386635j, 0.05578802 + 0.21864595j, 0, 0],
-                        [0.18579927 + 0.12805072j, -0.95671077 + 0.18381011j, 0, 0],
-                        [0, 0, -0.50373461 + 0.83386635j, 0.05578802 + 0.21864595j],
-                        [0, 0, 0.18579927 + 0.12805072j, -0.95671077 + 0.18381011j],
-                    ]
-                ),
-            )
-        )
+def test_bloch_sphere_rotation() -> None:
+    gate = BlochSphereRotation(qubit=Qubit(0), axis=(0.8, -0.3, 1.5), angle=0.9468, phase=2.533)
+    np.testing.assert_almost_equal(
+        matrix_expander.get_matrix(gate, 2),
+        [
+            [-0.50373461 + 0.83386635j, 0.05578802 + 0.21864595j, 0, 0],
+            [0.18579927 + 0.12805072j, -0.95671077 + 0.18381011j, 0, 0],
+            [0, 0, -0.50373461 + 0.83386635j, 0.05578802 + 0.21864595j],
+            [0, 0, 0.18579927 + 0.12805072j, -0.95671077 + 0.18381011j],
+        ],
+    )
 
-    def test_controlled_gate(self):
-        gate = ControlledGate(
-            Qubit(2), BlochSphereRotation(qubit=Qubit(0), axis=(1, 0, 0), angle=math.pi, phase=math.pi / 2)
-        )
-        self.assertTrue(
-            np.allclose(
-                matrix_expander.get_matrix(gate, 3),
-                np.array(
-                    [
-                        [1, 0, 0, 0, 0, 0, 0, 0],
-                        [0, 1, 0, 0, 0, 0, 0, 0],
-                        [0, 0, 1, 0, 0, 0, 0, 0],
-                        [0, 0, 0, 1, 0, 0, 0, 0],
-                        [0, 0, 0, 0, 0, 1, 0, 0],
-                        [0, 0, 0, 0, 1, 0, 0, 0],
-                        [0, 0, 0, 0, 0, 0, 0, 1],
-                        [0, 0, 0, 0, 0, 0, 1, 0],
-                    ]
-                ),
-            )
-        )
 
-    def test_matrix_gate(self):
-        gate = MatrixGate(
-            np.array(
-                [
-                    [1, 0, 0, 0],
-                    [0, 0, 1, 0],
-                    [0, 1, 0, 0],
-                    [0, 0, 0, 1],
-                ]
-            ),
-            operands=[Qubit(1), Qubit(2)],
-        )
-        self.assertTrue(
-            np.allclose(
-                matrix_expander.get_matrix(gate, 3),
-                np.array(
-                    [
-                        [1, 0, 0, 0, 0, 0, 0, 0],
-                        [0, 1, 0, 0, 0, 0, 0, 0],
-                        [0, 0, 0, 0, 1, 0, 0, 0],
-                        [0, 0, 0, 0, 0, 1, 0, 0],
-                        [0, 0, 1, 0, 0, 0, 0, 0],
-                        [0, 0, 0, 1, 0, 0, 0, 0],
-                        [0, 0, 0, 0, 0, 0, 1, 0],
-                        [0, 0, 0, 0, 0, 0, 0, 1],
-                    ]
-                ),
-            )
-        )
+def test_controlled_gate() -> None:
+    gate = ControlledGate(
+        Qubit(2), BlochSphereRotation(qubit=Qubit(0), axis=(1, 0, 0), angle=math.pi, phase=math.pi / 2)
+    )
+    np.testing.assert_almost_equal(
+        matrix_expander.get_matrix(gate, 3),
+        [
+            [1, 0, 0, 0, 0, 0, 0, 0],
+            [0, 1, 0, 0, 0, 0, 0, 0],
+            [0, 0, 1, 0, 0, 0, 0, 0],
+            [0, 0, 0, 1, 0, 0, 0, 0],
+            [0, 0, 0, 0, 0, 1, 0, 0],
+            [0, 0, 0, 0, 1, 0, 0, 0],
+            [0, 0, 0, 0, 0, 0, 0, 1],
+            [0, 0, 0, 0, 0, 0, 1, 0],
+        ],
+    )
+
+
+def test_matrix_gate() -> None:
+    gate = MatrixGate(
+        np.array(
+            [
+                [1, 0, 0, 0],
+                [0, 0, 1, 0],
+                [0, 1, 0, 0],
+                [0, 0, 0, 1],
+            ]
+        ),
+        operands=[Qubit(1), Qubit(2)],
+    )
+    np.testing.assert_almost_equal(
+        matrix_expander.get_matrix(gate, 3),
+        [
+            [1, 0, 0, 0, 0, 0, 0, 0],
+            [0, 1, 0, 0, 0, 0, 0, 0],
+            [0, 0, 0, 0, 1, 0, 0, 0],
+            [0, 0, 0, 0, 0, 1, 0, 0],
+            [0, 0, 1, 0, 0, 0, 0, 0],
+            [0, 0, 0, 1, 0, 0, 0, 0],
+            [0, 0, 0, 0, 0, 0, 1, 0],
+            [0, 0, 0, 0, 0, 0, 0, 1],
+        ],
+    )


### PR DESCRIPTION
This pull request converts the `unittest` style tests to the `pytest` format. All tests have been updated with the exception of the tests for the quantify scheduler. These tests should probably be redesigned to use `quantify_scheduler` instead of mocking its behavior.

Closes #215