### PR TITLE
208 axis object

### DIFF
--- a/opensquirrel/circuit.py
+++ b/opensquirrel/circuit.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Callable, Mapping
-from typing import TYPE_CHECKING, Any, Literal
+from typing import Any, Literal
 
 from opensquirrel.decomposer import general_decomposer
 from opensquirrel.decomposer.general_decomposer import Decomposer

--- a/opensquirrel/common.py
+++ b/opensquirrel/common.py
@@ -1,11 +1,9 @@
 from __future__ import annotations
 
-import cmath
 import math
-from collections.abc import Iterable
 
 import numpy as np
-from numpy.typing import ArrayLike, NDArray
+from numpy.typing import NDArray
 
 ATOL = 0.0000001
 
@@ -17,34 +15,6 @@ def normalize_angle(x: float) -> float:
     elif t > math.pi:
         t -= 2 * math.pi
     return t
-
-
-def normalize_axis(axis: ArrayLike) -> NDArray[np.float_]:
-    axis = np.asarray(axis, dtype=np.float_)
-    norm = np.linalg.norm(axis)
-    axis /= norm
-    return axis
-
-
-X = np.array([[0, 1], [1, 0]])
-Y = np.array([[0, -1j], [1j, 0]])
-Z = np.array([[1, 0], [0, -1]])
-
-
-def can1(axis: Iterable[float], angle: float, phase: float = 0) -> NDArray[np.complex_]:
-    nx, ny, nz = axis
-    norm = math.sqrt(nx**2 + ny**2 + nz**2)
-    assert norm > 0.00000001
-
-    nx /= norm
-    ny /= norm
-    nz /= norm
-
-    result = cmath.rect(1, phase) * (
-        math.cos(angle / 2) * np.identity(2) - 1j * math.sin(angle / 2) * (nx * X + ny * Y + nz * Z)
-    )
-
-    return np.asarray(result, dtype=np.complex_)
 
 
 def are_matrices_equivalent_up_to_global_phase(matrix_a: NDArray[np.complex_], matrix_b: NDArray[np.complex_]) -> bool:

--- a/opensquirrel/decomposer/zyz_decomposer.py
+++ b/opensquirrel/decomposer/zyz_decomposer.py
@@ -1,32 +1,29 @@
 from __future__ import annotations
 
 import math
-from collections.abc import Iterable
 
 from opensquirrel.common import ATOL
 from opensquirrel.decomposer.general_decomposer import Decomposer
 from opensquirrel.default_gates import Ry, Rz
-from opensquirrel.ir import BlochSphereRotation, Float, Gate
+from opensquirrel.ir import Axis, AxisLike, BlochSphereRotation, Float, Gate
 from opensquirrel.utils.identity_filter import filter_out_identities
 
 
-def get_zyz_decomposition_angles(alpha: float, axis: Iterable[float]) -> tuple[float, float, float]:
+def get_zyz_decomposition_angles(alpha: float, axis: AxisLike) -> tuple[float, float, float]:
     """
     Gives the angles used in the Z-Y-Z decomposition of the Bloch sphere rotation
     characterized by a rotation around `axis` of angle `alpha`.
 
     Parameters:
-        alpha: angle of the Bloch sphere rotation
-        axis: _normalized_ axis of the Bloch sphere rotation
+        alpha: angle of the Bloch sphere rotation.
+        axis: AxisLike object of the Bloch sphere rotation.
 
     Returns:
         A triple (theta1, theta2, theta3) corresponding to the decomposition of the
         arbitrary Bloch sphere rotation into U = Rz(theta3) Ry(theta2) Rz(theta1)
 
     """
-    nx, ny, nz = axis
-
-    assert abs(nx**2 + ny**2 + nz**2 - 1) < ATOL, "Axis needs to be normalized"
+    _, ny, nz = Axis(axis)
 
     assert -math.pi + ATOL < alpha <= math.pi + ATOL, "Angle needs to be normalized"
 
@@ -62,7 +59,7 @@ def get_zyz_decomposition_angles(alpha: float, axis: Iterable[float]) -> tuple[f
         if abs(math.sin(theta2 / 2)) < ATOL:
             m = p  # This can be anything, but setting m = p means theta3 == 0, which is better for gate count.
         else:
-            acos_argument = ny * math.sin(alpha / 2) / math.sin(theta2 / 2)
+            acos_argument = float(ny) * math.sin(alpha / 2) / math.sin(theta2 / 2)
 
             # This fixes float approximations like 1.0000000000002 which acos doesn't like.
             acos_argument = max(min(acos_argument, 1.0), -1.0)

--- a/opensquirrel/ir.py
+++ b/opensquirrel/ir.py
@@ -5,7 +5,7 @@ from abc import ABC, abstractmethod
 from collections.abc import Callable
 from dataclasses import dataclass
 from functools import wraps
-from typing import Any, Sequence, TypeAlias, overload
+from typing import Any, Sequence, TypeAlias, cast, overload
 
 import numpy as np
 from numpy.typing import ArrayLike, NDArray
@@ -87,8 +87,9 @@ class Qubit(Expression):
 
 class Axis(Sequence[np.float64], Expression):
 
-    def __init__(self, axis: AxisLike) -> None:
-        self._axis = self._parse_axislike(axis)
+    def __init__(self, *axis: AxisLike) -> None:
+        axis_to_parse = axis[0] if len(axis) == 1 else cast(AxisLike, axis)
+        self._axis = self._parse_axislike(axis_to_parse)
 
     @property
     def axis(self) -> NDArray[np.float64]:
@@ -115,7 +116,7 @@ class Axis(Sequence[np.float64], Expression):
         return normalize_axis(axis)
 
     def __getitem__(self, index: int, /) -> np.float64:  # type:ignore[override]
-        return self.axis[index]  # type: ignore[no-any-return]
+        return cast(np.float64, self.axis[index])
 
     def __len__(self) -> int:
         return 3

--- a/opensquirrel/ir.py
+++ b/opensquirrel/ir.py
@@ -86,21 +86,46 @@ class Qubit(Expression):
 
 
 class Axis(Sequence[np.float64], Expression):
+    """The ``Axis`` object parses and stores a vector containing 3 elements.
+
+    The input vector is always normalized before it is stored.
+    """
 
     def __init__(self, *axis: AxisLike) -> None:
+        """Init of the ``Axis`` object.
+
+        axis: An ``AxisLike`` to create the axis from.
+        """
         axis_to_parse = axis[0] if len(axis) == 1 else cast(AxisLike, axis)
-        self._axis = self._parse_axislike(axis_to_parse)
+        self._axis = self._parse_and_validate_axislike(axis_to_parse)
 
     @property
     def axis(self) -> NDArray[np.float64]:
+        """The ``Axis`` data saved as a 1D-Array with 3 elements."""
         return self._axis
 
     @axis.setter
     def axis(self, axis: AxisLike) -> None:
-        self._axis = self._parse_axislike(axis)
+        """Parse and set a new axis.
+
+        Args:
+            axis: An ``AxisLike`` to create the axis from.
+        """
+        self._axis = self._parse_and_validate_axislike(axis)
 
     @classmethod
-    def _parse_axislike(cls, axis: AxisLike) -> NDArray[np.float64]:
+    def _parse_and_validate_axislike(cls, axis: AxisLike) -> NDArray[np.float64]:
+        """Parse and validate an ``AxisLike``.
+
+        Check if the `axis` can be cast to a 1DArray of length 3, raise an error
+        otherwise. After casting to an array, the axis is normalized.
+
+        Args:
+            axis: ``AxisLike`` to validate and parse.
+
+        Returns:
+            Parsed axis represented as a 1DArray of length 3.
+        """
         if isinstance(axis, Axis):
             return axis.axis
 
@@ -117,24 +142,41 @@ class Axis(Sequence[np.float64], Expression):
 
     @staticmethod
     def _normalize_axis(axis: NDArray[np.float64]) -> NDArray[np.float64]:
+        """Normalize a NDArray.
+
+        Args:
+            axis: NDArray to normalize.
+
+        Returns:
+            Normalized NDArray.
+        """
         return axis / np.linalg.norm(axis)
 
     def __getitem__(self, index: int, /) -> np.float64:  # type:ignore[override]
+        """Get the item at `index`."""
         return cast(np.float64, self.axis[index])
 
     def __len__(self) -> int:
+        """Length of the axis, which is always 3."""
         return 3
 
     def __repr__(self) -> str:
+        """String representation of the ``Axis``."""
         return f"Axis{self.axis}"
 
     def __array__(self, dtype: DTypeLike = None, copy: bool = True) -> NDArray[Any]:
+        """Convert the ``Axis`` data to an array."""
         return np.array(self.axis, dtype=dtype, copy=copy)
 
     def accept(self, visitor: IRVisitor) -> Any:
+        """Accept the ``Axis``."""
         return visitor.visit_axis(self)
 
     def __eq__(self, other: Any) -> bool:
+        """Check if `self` is equal to other.
+
+        Two ``Axis`` objects are considered equal if their axes are equal.
+        """
         if not isinstance(other, Axis):
             return False
         return np.array_equal(self, other)

--- a/opensquirrel/ir.py
+++ b/opensquirrel/ir.py
@@ -128,6 +128,9 @@ class Axis(Sequence[np.float64], Expression):
     def __repr__(self) -> str:
         return f"Axis{self.axis}"
 
+    def __array__(self, dtype: DTypeLike = None, copy: bool = True) -> NDArray[Any]:
+        return np.array(self.axis, dtype=dtype, copy=copy)
+
     def accept(self, visitor: IRVisitor) -> Any:
         return visitor.visit_axis(self)
 
@@ -254,9 +257,6 @@ class BlochSphereRotation(Gate):
         if np.allclose(self.axis.axis, -other.axis.axis):
             return abs(self.angle + other.angle) < ATOL
         return False
-
-    def __array__(self, dtype: DTypeLike = None, copy: bool | None = None) -> NDArray[Any]:
-        return np.array(self.axis, dtype=dtype, copy=copy)
 
     def accept(self, visitor: IRVisitor) -> Any:
         visitor.visit_gate(self)

--- a/opensquirrel/ir.py
+++ b/opensquirrel/ir.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import inspect
 from abc import ABC, abstractmethod
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 from dataclasses import dataclass
 from functools import wraps
 from typing import Any, overload
@@ -80,6 +80,39 @@ class Qubit(Expression):
 
     def accept(self, visitor: IRVisitor) -> Any:
         return visitor.visit_qubit(self)
+
+
+class Axis(Sequence, Expression):
+
+    def __init__(self, axis: ArrayLike) -> None:
+        self.axis = axis
+
+    @property
+    def axis(self) -> NDArray[np.float_]:
+        return self._axis
+
+    @axis.setter
+    def axis(self, axis: ArrayLike) -> None:
+        try:
+            axis = np.asfarray(axis)
+        except (ValueError, TypeError) as e:
+            raise TypeError("Axis requires an ArrayLike") from e
+        axis = axis.flatten()
+        if len(axis) != 3:
+            raise ValueError(
+                f"Axis requires an ArrayLike of length 3, but received an ArrayLike of length {len(axis)}."
+            )
+        axis = normalize_axis(axis)
+        self._axis = axis
+
+    def __getitem__(self, index: int) -> np.float_:
+        return self.axis[index]
+
+    def __len__(self) -> int:
+        return len(self.axis)
+
+    def accept(self) -> str:
+        return str(self.axis)
 
 
 class Statement(IRNode, ABC):

--- a/opensquirrel/ir.py
+++ b/opensquirrel/ir.py
@@ -134,6 +134,11 @@ class Axis(Sequence[np.float64], Expression):
     def accept(self, visitor: IRVisitor) -> Any:
         return visitor.visit_axis(self)
 
+    def __eq__(self, other: Any) -> bool:
+        if not isinstance(other, Axis):
+            return False
+        return np.array_equal(self, other)
+
 
 class Statement(IRNode, ABC):
     pass

--- a/opensquirrel/ir.py
+++ b/opensquirrel/ir.py
@@ -109,7 +109,7 @@ class Axis(Sequence, Expression):
         return self.axis[index]
 
     def __len__(self) -> int:
-        return len(self.axis)
+        return 3
 
     def accept(self) -> str:
         return str(self.axis)

--- a/opensquirrel/mapper/qubit_remapper.py
+++ b/opensquirrel/mapper/qubit_remapper.py
@@ -1,4 +1,3 @@
-
 from opensquirrel.circuit import Circuit
 from opensquirrel.ir import (
     IR,

--- a/opensquirrel/mapper/qubit_remapper.py
+++ b/opensquirrel/mapper/qubit_remapper.py
@@ -1,4 +1,3 @@
-from typing import List
 
 from opensquirrel.circuit import Circuit
 from opensquirrel.ir import (

--- a/opensquirrel/merger/general_merger.py
+++ b/opensquirrel/merger/general_merger.py
@@ -32,8 +32,8 @@ def compose_bloch_sphere_rotations(a: BlochSphereRotation, b: BlochSphereRotatio
             1
             / sin(combined_angle / 2)
             * (
-                sin(a.angle / 2) * cos(b.angle / 2) * a.axis
-                + cos(a.angle / 2) * sin(b.angle / 2) * b.axis
+                sin(a.angle / 2) * cos(b.angle / 2) * a.axis.axis
+                + cos(a.angle / 2) * sin(b.angle / 2) * b.axis.axis
                 + sin(a.angle / 2) * sin(b.angle / 2) * np.cross(a.axis, b.axis)
             )
         ),

--- a/opensquirrel/utils/matrix_expander.py
+++ b/opensquirrel/utils/matrix_expander.py
@@ -1,13 +1,14 @@
 from __future__ import annotations
 
+import cmath
+import math
 from collections.abc import Iterable
 from typing import cast
 
 import numpy as np
 from numpy.typing import NDArray
 
-from opensquirrel.common import can1
-from opensquirrel.ir import BlochSphereRotation, ControlledGate, Gate, IRVisitor, MatrixGate, Qubit
+from opensquirrel.ir import Axis, AxisLike, BlochSphereRotation, ControlledGate, Gate, IRVisitor, MatrixGate, Qubit
 
 
 def get_reduced_ket(ket: int, qubits: Iterable[Qubit]) -> int:
@@ -143,6 +144,21 @@ class MatrixExpander(IRVisitor):
 
         assert expanded_matrix.shape == (1 << self.qubit_register_size, 1 << self.qubit_register_size)
         return expanded_matrix
+
+
+X = np.array([[0, 1], [1, 0]])
+Y = np.array([[0, -1j], [1j, 0]])
+Z = np.array([[1, 0], [0, -1]])
+
+
+def can1(axis: AxisLike, angle: float, phase: float = 0) -> NDArray[np.complex_]:
+    nx, ny, nz = Axis(axis)
+
+    result = cmath.rect(1, phase) * (
+        math.cos(angle / 2) * np.identity(2) - 1j * math.sin(angle / 2) * (nx * X + ny * Y + nz * Z)
+    )
+
+    return np.asarray(result, dtype=np.complex_)
 
 
 def get_matrix(gate: Gate, qubit_register_size: int) -> NDArray[np.complex_]:

--- a/test/test_ir.py
+++ b/test/test_ir.py
@@ -156,7 +156,7 @@ class TestMeasure:
         return Measure(Qubit(42), axis=(0, 0, 1))
 
     def test_repr(self, measure: Measure) -> None:
-        expected_repr = "Measure(Qubit[42], axis=[0. 0. 1.])"
+        expected_repr = "Measure(Qubit[42], axis=Axis[0. 0. 1.])"
         assert repr(measure) == expected_repr
 
     def test_equality(self, measure: Measure) -> None:

--- a/test/test_ir.py
+++ b/test/test_ir.py
@@ -57,8 +57,8 @@ class TestAxis:
     def test_len(self, axis: Axis) -> None:
         assert len(axis) == 3
 
-    def test_accept(self, axis: Axis) -> None:
-        assert axis.accept() == "[1. 0. 0.]"
+    def test_repr(self, axis: Axis) -> None:
+        assert repr(axis) == "Axis[1. 0. 0.]"
 
 
 class TestIR:

--- a/test/test_ir.py
+++ b/test/test_ir.py
@@ -62,6 +62,17 @@ class TestAxis:
     def test_repr(self, axis: Axis) -> None:
         assert repr(axis) == "Axis[1. 0. 0.]"
 
+    def test_array(self, axis: Axis) -> None:
+        np.testing.assert_array_equal(axis, [1, 0, 0])
+
+    @pytest.mark.parametrize("other", [Axis(1, 0, 0), Axis([1, 0, 0]), Axis([[1], [0], [0]])])
+    def test_eq_true(self, axis: Axis, other: Any) -> None:
+        assert axis == other
+
+    @pytest.mark.parametrize("other", ["test", Axis(0, 1, 0)])
+    def test_eq_false(self, axis: Axis, other: Any) -> None:
+        assert axis != other
+
 
 class TestIR:
     def test_cnot_equality(self) -> None:

--- a/test/test_ir.py
+++ b/test/test_ir.py
@@ -16,7 +16,7 @@ class TestAxis:
 
     @pytest.fixture(name="axis")
     def axis_fixture(self) -> Axis:
-        return Axis((1, 0, 0))
+        return Axis(1, 0, 0)
 
     @pytest.mark.parametrize("expected_class", [Sequence, Expression])
     def test_inheritance(self, axis: Axis, expected_class: type[Any]) -> None:
@@ -25,7 +25,9 @@ class TestAxis:
     def test_axis_getter(self, axis: Axis) -> None:
         np.testing.assert_array_equal(axis.axis, [1, 0, 0])
 
-    @pytest.mark.parametrize("new_axis, expected_axis", [([0, 0, 1], [0, 0, 1]), ([0, 3, 4], [0, 3 / 5, 4 / 5])])
+    @pytest.mark.parametrize(
+        "new_axis, expected_axis", [([0, 0, 1], [0, 0, 1]), ([0, 3, 4], [0, 3 / 5, 4 / 5]), (Axis(0, 1, 0), [0, 1, 0])]
+    )
     def test_axis_setter_no_error(self, axis: Axis, new_axis: ArrayLike, expected_axis: ArrayLike) -> None:
         axis.axis = new_axis
         np.testing.assert_array_equal(axis.axis, expected_axis)

--- a/test/test_ir.py
+++ b/test/test_ir.py
@@ -1,16 +1,68 @@
 from __future__ import annotations
 
 import math
+from collections.abc import Sequence
+from typing import Any
 
 import numpy as np
 import pytest
+from numpy.typing import ArrayLike
 
 from opensquirrel.common import ATOL
-from opensquirrel.ir import BlochSphereRotation, ControlledGate, MatrixGate, Measure, Qubit
+from opensquirrel.ir import Axis, BlochSphereRotation, ControlledGate, Expression, MatrixGate, Measure, Qubit
+
+
+class TestAxis:
+
+    @pytest.fixture(name="axis")
+    def axis_fixture(self) -> Axis:
+        return Axis((1, 0, 0))
+
+    @pytest.mark.parametrize("expected_class", [Sequence, Expression])
+    def test_inheritance(self, axis: Axis, expected_class: type[Any]) -> None:
+        assert isinstance(axis, expected_class)
+
+    def test_axis_getter(self, axis: Axis) -> None:
+        np.testing.assert_array_equal(axis.axis, [1, 0, 0])
+
+    @pytest.mark.parametrize("new_axis, expected_axis", [([0, 0, 1], [0, 0, 1]), ([0, 3, 4], [0, 3 / 5, 4 / 5])])
+    def test_axis_setter_no_error(self, axis: Axis, new_axis: ArrayLike, expected_axis: ArrayLike) -> None:
+        axis.axis = new_axis
+        np.testing.assert_array_equal(axis.axis, expected_axis)
+
+    @pytest.mark.parametrize(
+        "erroneous_axis, expected_error, expected_error_message",
+        [
+            (Qubit(1), TypeError, "Axis requires an ArrayLike"),
+            ([0, [3], [2]], TypeError, "Axis requires an ArrayLike"),
+            (0, ValueError, "Axis requires an ArrayLike of length 3, but received an ArrayLike of length 1."),
+            (
+                [1, 2, 3, 4],
+                ValueError,
+                "Axis requires an ArrayLike of length 3, but received an ArrayLike of length 4.",
+            ),
+        ],
+    )
+    def test_axis_setter_with_error(
+        self, axis: Axis, erroneous_axis: Any, expected_error: type[Exception], expected_error_message: str
+    ) -> None:
+        with pytest.raises(expected_error, match=expected_error_message):
+            axis.axis = erroneous_axis
+
+    def test_get_item(self, axis: Axis) -> None:
+        assert axis[0] == 1
+        assert axis[1] == 0
+        assert axis[2] == 0
+
+    def test_len(self, axis: Axis) -> None:
+        assert len(axis) == 3
+
+    def test_accept(self, axis: Axis) -> None:
+        assert axis.accept() == "[1. 0. 0.]"
 
 
 class TestIR:
-    def test_cnot_equality(self):
+    def test_cnot_equality(self) -> None:
         matrix = np.array(
             [
                 [1, 0, 0, 0],
@@ -27,7 +79,7 @@ class TestIR:
 
         assert cnot_controlled_gate == cnot_matrix_gate
 
-    def test_different_qubits_gate(self):
+    def test_different_qubits_gate(self) -> None:
         matrix = np.array(
             [
                 [1, 0, 0, 0],
@@ -43,7 +95,7 @@ class TestIR:
 
         assert large_identity_matrix_gate == small_identity_control_gate
 
-    def test_inverse_gate(self):
+    def test_inverse_gate(self) -> None:
         matrix = np.array(
             [
                 [1, 0, 0, 0],
@@ -60,7 +112,7 @@ class TestIR:
 
         assert inverted_matrix_gate == inverted_cnot_gate
 
-    def test_global_phase(self):
+    def test_global_phase(self) -> None:
         matrix = np.array(
             [
                 [1j, 0, 0, 0],
@@ -77,7 +129,7 @@ class TestIR:
 
         assert inverted_matrix_with_phase == inverted_cnot_gate
 
-    def test_cnot_inequality(self):
+    def test_cnot_inequality(self) -> None:
         matrix = np.array(
             [
                 [1, 0, 0, 0],
@@ -162,8 +214,8 @@ class TestBlochSphereRotation:
     def test_get_qubit_operands(self, gate: BlochSphereRotation) -> None:
         assert gate.get_qubit_operands() == [Qubit(42)]
 
-    def test_is_identity(self, gate: BlochSphereRotation) -> bool:
-        assert BlochSphereRotation.identity(42).is_identity()
+    def test_is_identity(self, gate: BlochSphereRotation) -> None:
+        assert BlochSphereRotation.identity(Qubit(42)).is_identity()
         assert not gate.is_identity()
 
 
@@ -181,7 +233,7 @@ class TestMatrixGate:
         cnot_matrix_gate = MatrixGate(cnot_matrix, operands=[Qubit(42), Qubit(100)])
         return cnot_matrix_gate
 
-    def test_repr(self, gate: MatrixGate):
+    def test_repr(self, gate: MatrixGate) -> None:
         assert (
             repr(gate)
             == "MatrixGate(qubits=[Qubit[42], Qubit[100]], matrix=[[1 0 0 0]\n [0 1 0 0]\n [0 0 0 1]\n [0 0 1 0]])"


### PR DESCRIPTION
This merge request contains the following:
- An `Axis` object to handle axis parsing, validation and operations.
- An `AxisLike` type alias to annotate what can be converted to this `Axis` object.

One of the core ideas of the `Axis` object is that it can take any input that looks like an axis and create a axis from it. Hence it improves the user friendliness of out program. For example `Axis((1,2,3))`, `Axis(1,2,3)`, `Axis(1.0, 2.0, 3.0), `Axis(np.array([1,2,3]))` and `Axis([[1],[2],[3]])` are all allowed and result in equal axis objects.

During initialization and setting of the `Axis.axis` property, the underlying 1DArray is normalized. Hence, an `Axis` object is *always* normalized.