### PR TITLE
83 fix non existing qubit index not giving error

### DIFF
--- a/opensquirrel/circuit_builder.py
+++ b/opensquirrel/circuit_builder.py
@@ -107,8 +107,6 @@ class CircuitBuilder(GateLibrary, MeasurementLibrary):
             attr: Type of instruction
             args: Arguments parsed into the function
 
-        Returns:
-
         """
         for i, par in enumerate(inspect.signature(generator_f).parameters.values()):
             if isinstance(par.annotation, str):

--- a/opensquirrel/circuit_builder.py
+++ b/opensquirrel/circuit_builder.py
@@ -11,7 +11,7 @@ from opensquirrel.circuit import Circuit
 from opensquirrel.default_gates import default_gate_aliases, default_gate_set
 from opensquirrel.default_measurements import default_measurement_set
 from opensquirrel.instruction_library import GateLibrary, MeasurementLibrary
-from opensquirrel.ir import IR, Comment, Gate, Measure, Bit, Qubit
+from opensquirrel.ir import IR, Bit, Comment, Gate, Measure, Qubit
 from opensquirrel.register_manager import BitRegister, QubitRegister, RegisterManager
 
 
@@ -99,7 +99,7 @@ class CircuitBuilder(GateLibrary, MeasurementLibrary):
     def _check_generator_f_args(
         self, generator_f: Callable[..., Gate | Measure], attr: str, args: tuple[Any, ...]
     ) -> None:
-        """ General instruction validation function. The function checks if each instruction has the proper arguments
+        """General instruction validation function. The function checks if each instruction has the proper arguments
         and if the qubit and bits are within the register range.
 
         Args:

--- a/opensquirrel/circuit_builder.py
+++ b/opensquirrel/circuit_builder.py
@@ -11,7 +11,7 @@ from opensquirrel.circuit import Circuit
 from opensquirrel.default_gates import default_gate_aliases, default_gate_set
 from opensquirrel.default_measurements import default_measurement_set
 from opensquirrel.instruction_library import GateLibrary, MeasurementLibrary
-from opensquirrel.ir import IR, Comment, Gate, Measure
+from opensquirrel.ir import IR, Comment, Gate, Measure, Bit, Qubit
 from opensquirrel.register_manager import BitRegister, QubitRegister, RegisterManager
 
 
@@ -79,16 +79,37 @@ class CircuitBuilder(GateLibrary, MeasurementLibrary):
         return self
 
     def _check_qubit_out_of_bounds_access(self, index: int) -> None:
+        """Throw error if qubit index is outside the qubit register range.
+
+        Args:
+            index: qubit index
+        """
         if index >= self.register_manager.get_qubit_register_size():
             raise IndexError("Qubit index is out of bounds")
 
     def _check_bit_out_of_bounds_access(self, index: int) -> None:
+        """Throw error if bit index is outside the qubit register range.
+
+        Args:
+            index: bit index
+        """
         if index >= self.register_manager.get_bit_register_size():
             raise IndexError("Bit index is out of bounds")
 
     def _check_generator_f_args(
         self, generator_f: Callable[..., Gate | Measure], attr: str, args: tuple[Any, ...]
     ) -> None:
+        """ General instruction validation function. The function checks if each instruction has the proper arguments
+        and if the qubit and bits are within the register range.
+
+        Args:
+            generator_f: Instruction function
+            attr: Type of instruction
+            args: Arguments parsed into the function
+
+        Returns:
+
+        """
         for i, par in enumerate(inspect.signature(generator_f).parameters.values()):
             if isinstance(par.annotation, str):
                 if args[i].__class__.__name__ != par.annotation:

--- a/test/test_circuit_builder.py
+++ b/test/test_circuit_builder.py
@@ -78,6 +78,19 @@ class TestCircuitBuilder:
             CNOT(Qubit(0), Qubit(1)),
         ]
 
+    def test_gate_index_error(self):
+        builder = CircuitBuilder(2)
+
+        with pytest.raises(Exception) as exception_info:
+            builder.H(Qubit(0)).CNOT(Qubit(0), Qubit(12)).to_circuit()
+        assert re.search("Qubit index does not exist in circuit.", str(exception_info.value))
+
+    def test_measurement_index_error(self):
+        builder = CircuitBuilder(2, 1)
+        with pytest.raises(Exception) as exception_info:
+            builder.H(Qubit(0)).measure(Qubit(0), Bit(10)).to_circuit()
+        assert re.search("Bit index does not exist in circuit.", str(exception_info.value))
+
     def test_unknown_instruction(self):
         builder = CircuitBuilder(3)
 


### PR DESCRIPTION
This addition solves the bug where a user can add a Gate or Measurement which surpasses the qubit or bit index of the given circuit. 