### PR TITLE
Cqt 51 replace tests using c qasm strings with circuits generated through the circuit builder

### DIFF
--- a/opensquirrel/exporter/quantify_scheduler_exporter.py
+++ b/opensquirrel/exporter/quantify_scheduler_exporter.py
@@ -102,7 +102,7 @@ def export(circuit: Circuit) -> "quantify_scheduler.Schedule":
         circuit.ir.accept(schedule_creator)
     except UnsupportedGateError as e:
         raise ExporterError(
-            f"cannot export circuit: {e} ."
+            f"cannot export circuit: {e}. "
             "Decompose all gates to the Quantify-scheduler gate set first (rxy, rz, cnot, cz)"
         ) from e
     return schedule_creator.schedule

--- a/test/exporter/test_quantify_scheduler_exporter.py
+++ b/test/exporter/test_quantify_scheduler_exporter.py
@@ -7,12 +7,8 @@ import pytest
 
 from opensquirrel import CircuitBuilder
 from opensquirrel.common import ATOL
-<<<<<<< HEAD
-from opensquirrel.default_gates import CCZ, CZ, SWAP, H, Ry, Rz, X
-from opensquirrel.exceptions import ExporterError
-=======
 from opensquirrel.default_gates import CCZ, SWAP, H
->>>>>>> 2b367dd (Builder instead of IR for circuit creation)
+from opensquirrel.exceptions import ExporterError
 from opensquirrel.exporter import quantify_scheduler_exporter
 from opensquirrel.exporter.quantify_scheduler_exporter import DEG_PRECISION
 from opensquirrel.ir import Bit, BlochSphereRotation, Float, Gate, Qubit
@@ -96,7 +92,7 @@ class TestQuantifySchedulerExporter:
         circuit = builder.to_circuit()
 
         with MockedQuantifyScheduler():
-            with pytest.raises(ExporterError, match="Cannot export circuit: it contains unsupported gates"):
+            with pytest.raises(ExporterError, match="cannot export circuit: "):
                 quantify_scheduler_exporter.export(circuit)
 
 
@@ -105,5 +101,7 @@ class TestQuantifySchedulerExporter:
 )
 def test_quantify_scheduler_not_installed() -> None:
     empty_circuit = CircuitBuilder(1).to_circuit()
-    with pytest.raises(ModuleNotFoundError, match="quantify-scheduler is not installed, or cannot be installed on your system"):
+    with pytest.raises(
+        ModuleNotFoundError, match="quantify-scheduler is not installed, or cannot be installed on your system"
+    ):
         quantify_scheduler_exporter.export(empty_circuit)

--- a/test/exporter/test_quantify_scheduler_exporter.py
+++ b/test/exporter/test_quantify_scheduler_exporter.py
@@ -44,15 +44,15 @@ class MockedQuantifyScheduler:
 
 class TestQuantifySchedulerExporter:
     def test_export(self):
-        circuit_builder = CircuitBuilder(3, 3)
-        circuit_builder.X(Qubit(0))
-        circuit_builder.CZ(Qubit(0), Qubit(1))
-        circuit_builder.Rz(Qubit(1), Float(2.34))
-        circuit_builder.Ry(Qubit(2), Float(1.23))
-        circuit_builder.measure(Qubit(0), Bit(0))
-        circuit_builder.measure(Qubit(1), Bit(1))
-        circuit_builder.measure(Qubit(2), Bit(2))
-        circuit = circuit_builder.to_circuit()
+        builder = CircuitBuilder(3, 3)
+        builder.X(Qubit(0))
+        builder.CZ(Qubit(0), Qubit(1))
+        builder.Rz(Qubit(1), Float(2.34))
+        builder.Ry(Qubit(2), Float(1.23))
+        builder.measure(Qubit(0), Bit(0))
+        builder.measure(Qubit(1), Bit(1))
+        builder.measure(Qubit(2), Bit(2))
+        circuit = builder.to_circuit()
 
         with MockedQuantifyScheduler() as (mock_quantify_scheduler, mock_quantify_scheduler_gates):
             mock_schedule = unittest.mock.MagicMock()

--- a/test/exporter/test_quantify_scheduler_exporter.py
+++ b/test/exporter/test_quantify_scheduler_exporter.py
@@ -78,7 +78,6 @@ class TestQuantifySchedulerExporter:
             )
             assert mock_schedule.add.call_count == 7
 
-
     @pytest.mark.parametrize(
         "gate",
         [
@@ -87,7 +86,7 @@ class TestQuantifySchedulerExporter:
             BlochSphereRotation(qubit=Qubit(0), axis=(1, 2, 3), angle=0.9876, phase=2.34),
             CCZ(Qubit(0), Qubit(1), Qubit(2)),
         ],
-        ids=["H", "SWAP", "BSR", "CCZ"]
+        ids=["H", "SWAP", "BSR", "CCZ"],
     )
     def test_gates_not_supported(self, gate: Gate) -> None:
         register_manager = RegisterManager(QubitRegister(3))

--- a/test/exporter/test_quantify_scheduler_exporter.py
+++ b/test/exporter/test_quantify_scheduler_exporter.py
@@ -6,14 +6,16 @@ import unittest.mock
 import pytest
 
 from opensquirrel import CircuitBuilder
-from opensquirrel.circuit import Circuit
 from opensquirrel.common import ATOL
+<<<<<<< HEAD
 from opensquirrel.default_gates import CCZ, CZ, SWAP, H, Ry, Rz, X
 from opensquirrel.exceptions import ExporterError
+=======
+from opensquirrel.default_gates import CCZ, SWAP, H
+>>>>>>> 2b367dd (Builder instead of IR for circuit creation)
 from opensquirrel.exporter import quantify_scheduler_exporter
 from opensquirrel.exporter.quantify_scheduler_exporter import DEG_PRECISION
-from opensquirrel.ir import IR, Bit, BlochSphereRotation, Float, Gate, Measure, Qubit
-from opensquirrel.register_manager import BitRegister, QubitRegister, RegisterManager
+from opensquirrel.ir import Bit, BlochSphereRotation, Float, Gate, Qubit
 
 
 class FloatEq(float):
@@ -89,13 +91,13 @@ class TestQuantifySchedulerExporter:
         ids=["H", "SWAP", "BSR", "CCZ"],
     )
     def test_gates_not_supported(self, gate: Gate) -> None:
-        register_manager = RegisterManager(QubitRegister(3))
-        ir = IR()
-        ir.add_gate(gate)
+        builder = CircuitBuilder(3)
+        builder.ir.add_gate(gate)
+        circuit = builder.to_circuit()
 
         with MockedQuantifyScheduler():
-            with pytest.raises(ExporterError, match="cannot export circuit: "):
-                quantify_scheduler_exporter.export(Circuit(register_manager, ir))
+            with pytest.raises(ExporterError, match="Cannot export circuit: it contains unsupported gates"):
+                quantify_scheduler_exporter.export(circuit)
 
 
 @pytest.mark.skipif(

--- a/test/mapper/test_general_mapper.py
+++ b/test/mapper/test_general_mapper.py
@@ -30,23 +30,23 @@ class TestMapper:
 class TestMapQubits:
     @pytest.fixture(name="circuit")
     def circuit_fixture(self) -> Circuit:
-        circuit_builder = CircuitBuilder(3, 1)
-        circuit_builder.H(Qubit(0))
-        circuit_builder.CNOT(Qubit(0), Qubit(1))
-        circuit_builder.CNOT(Qubit(1), Qubit(2))
-        circuit_builder.comment("Qubit[1]")
-        circuit_builder.measure(Qubit(0), Bit(0))
-        return circuit_builder.to_circuit()
+        builder = CircuitBuilder(3, 1)
+        builder.H(Qubit(0))
+        builder.CNOT(Qubit(0), Qubit(1))
+        builder.CNOT(Qubit(1), Qubit(2))
+        builder.comment("Qubit[1]")
+        builder.measure(Qubit(0), Bit(0))
+        return builder.to_circuit()
 
     @pytest.fixture(name="remapped_circuit")
     def remapped_circuit_fixture(self) -> Circuit:
-        circuit_builder = CircuitBuilder(3, 1)
-        circuit_builder.H(Qubit(1))
-        circuit_builder.CNOT(Qubit(1), Qubit(0))
-        circuit_builder.CNOT(Qubit(0), Qubit(2))
-        circuit_builder.comment("Qubit[1]")
-        circuit_builder.measure(Qubit(1), Bit(0))
-        return circuit_builder.to_circuit()
+        builder = CircuitBuilder(3, 1)
+        builder.H(Qubit(1))
+        builder.CNOT(Qubit(1), Qubit(0))
+        builder.CNOT(Qubit(0), Qubit(2))
+        builder.comment("Qubit[1]")
+        builder.measure(Qubit(1), Bit(0))
+        return builder.to_circuit()
 
     def test_circuit_map(self, circuit: Circuit, remapped_circuit: Circuit) -> None:
         mapper = HardcodedMapper(circuit.qubit_register_size, Mapping([1, 0, 2]))

--- a/test/mapper/test_general_mapper.py
+++ b/test/mapper/test_general_mapper.py
@@ -1,10 +1,8 @@
 from __future__ import annotations
 
-from typing import List
-
 import pytest
 
-from opensquirrel import Circuit
+from opensquirrel import Circuit, CircuitBuilder
 from opensquirrel.default_gates import CNOT, H
 from opensquirrel.ir import IR, Bit, Comment, Measure, Qubit, Statement
 from opensquirrel.mapper import HardcodedMapper, Mapper
@@ -34,17 +32,16 @@ class TestMapper:
 class TestMapQubits:
     @pytest.fixture(name="circuit")
     def circuit_fixture(self) -> Circuit:
-        register_manager = RegisterManager(QubitRegister(3), BitRegister(3))
-        ir = IR()
-        ir.add_gate(H(Qubit(0)))
-        ir.add_gate(CNOT(Qubit(0), Qubit(1)))
-        ir.add_gate(CNOT(Qubit(1), Qubit(2)))
-        ir.add_comment(Comment("Qubit[1]"))
-        ir.add_measurement(Measure(Qubit(0), Bit(0), axis=(0, 0, 1)))
-        return Circuit(register_manager, ir)
+        circuit_builder = CircuitBuilder(3, 1)
+        circuit_builder.H(Qubit(0))
+        circuit_builder.CNOT(Qubit(0), Qubit(1))
+        circuit_builder.CNOT(Qubit(1), Qubit(2))
+        circuit_builder.comment("Qubit[1]")
+        circuit_builder.measure(Qubit(0), Bit(0))
+        return circuit_builder.to_circuit()
 
     @pytest.fixture(name="expected_statements")
-    def expected_statements_fixture(self) -> List[Statement]:
+    def expected_statements_fixture(self) -> list[Statement]:
         return [
             H(Qubit(1)),
             CNOT(Qubit(1), Qubit(0)),

--- a/test/mapper/test_general_mapper.py
+++ b/test/mapper/test_general_mapper.py
@@ -3,11 +3,9 @@ from __future__ import annotations
 import pytest
 
 from opensquirrel import Circuit, CircuitBuilder
-from opensquirrel.default_gates import CNOT, H
-from opensquirrel.ir import IR, Bit, Comment, Measure, Qubit, Statement
+from opensquirrel.ir import Bit, Qubit
 from opensquirrel.mapper import HardcodedMapper, Mapper
 from opensquirrel.mapper.mapping import Mapping
-from opensquirrel.register_manager import BitRegister, QubitRegister, RegisterManager
 
 
 class TestMapper:
@@ -40,17 +38,17 @@ class TestMapQubits:
         circuit_builder.measure(Qubit(0), Bit(0))
         return circuit_builder.to_circuit()
 
-    @pytest.fixture(name="expected_statements")
-    def expected_statements_fixture(self) -> list[Statement]:
-        return [
-            H(Qubit(1)),
-            CNOT(Qubit(1), Qubit(0)),
-            CNOT(Qubit(0), Qubit(2)),
-            Comment("Qubit[1]"),
-            Measure(Qubit(1), Bit(1), axis=(0, 0, 1)),
-        ]
+    @pytest.fixture(name="remapped_circuit")
+    def remapped_circuit_fixture(self) -> Circuit:
+        circuit_builder = CircuitBuilder(3, 1)
+        circuit_builder.H(Qubit(1))
+        circuit_builder.CNOT(Qubit(1), Qubit(0))
+        circuit_builder.CNOT(Qubit(0), Qubit(2))
+        circuit_builder.comment("Qubit[1]")
+        circuit_builder.measure(Qubit(1), Bit(0))
+        return circuit_builder.to_circuit()
 
-    def test_circuit_map(self, circuit: Circuit, expected_statements: list[Statement]) -> None:
+    def test_circuit_map(self, circuit: Circuit, remapped_circuit: Circuit) -> None:
         mapper = HardcodedMapper(circuit.qubit_register_size, Mapping([1, 0, 2]))
         circuit.map(mapper)
-        assert circuit.ir.statements == expected_statements
+        assert circuit == remapped_circuit

--- a/test/mapper/test_qubit_remapper.py
+++ b/test/mapper/test_qubit_remapper.py
@@ -1,47 +1,46 @@
 import pytest
 
+from opensquirrel import CircuitBuilder
 from opensquirrel.circuit import Circuit
-from opensquirrel.default_gates import CNOT, H, X, Y
-from opensquirrel.ir import IR, Qubit
+from opensquirrel.ir import Qubit
 from opensquirrel.mapper.mapping import Mapping
 from opensquirrel.mapper.qubit_remapper import get_remapped_ir, remap_ir
-from opensquirrel.register_manager import QubitRegister, RegisterManager
 
 
 class TestRemapper:
     @pytest.fixture
     def circuit_3(self) -> Circuit:
-        ir = IR()
-        ir.add_gate(H(Qubit(0)))
-        ir.add_gate(CNOT(Qubit(0), Qubit(1)))
-        ir.add_gate(H(Qubit(2)))
-        return Circuit(RegisterManager(QubitRegister(3)), ir)
+        circuit_builder = CircuitBuilder(3)
+        circuit_builder.H(Qubit(0))
+        circuit_builder.CNOT(Qubit(0), Qubit(1))
+        circuit_builder.H(Qubit(2))
+        return circuit_builder.to_circuit()
 
     @pytest.fixture
     def circuit_3_remapped(self) -> Circuit:
-        ir = IR()
-        ir.add_gate(H(Qubit(2)))
-        ir.add_gate(CNOT(Qubit(2), Qubit(1)))
-        ir.add_gate(H(Qubit(0)))
-        return Circuit(RegisterManager(QubitRegister(3)), ir)
+        circuit_builder = CircuitBuilder(3)
+        circuit_builder.H(Qubit(2))
+        circuit_builder.CNOT(Qubit(2), Qubit(1))
+        circuit_builder.H(Qubit(0))
+        return circuit_builder.to_circuit()
 
     @pytest.fixture
     def circuit_4(self) -> Circuit:
-        ir = IR()
-        ir.add_gate(H(Qubit(0)))
-        ir.add_gate(CNOT(Qubit(0), Qubit(1)))
-        ir.add_gate(X(Qubit(2)))
-        ir.add_gate(Y(Qubit(3)))
-        return Circuit(RegisterManager(QubitRegister(4)), ir)
+        circuit_builder = CircuitBuilder(4)
+        circuit_builder.H(Qubit(0))
+        circuit_builder.CNOT(Qubit(0), Qubit(1))
+        circuit_builder.X(Qubit(2))
+        circuit_builder.Y(Qubit(3))
+        return circuit_builder.to_circuit()
 
     @pytest.fixture
     def circuit_4_remapped(self) -> Circuit:
-        ir = IR()
-        ir.add_gate(H(Qubit(3)))
-        ir.add_gate(CNOT(Qubit(3), Qubit(1)))
-        ir.add_gate(X(Qubit(0)))
-        ir.add_gate(Y(Qubit(2)))
-        return Circuit(RegisterManager(QubitRegister(4)), ir)
+        circuit_builder = CircuitBuilder(4)
+        circuit_builder.H(Qubit(3))
+        circuit_builder.CNOT(Qubit(3), Qubit(1))
+        circuit_builder.X(Qubit(0))
+        circuit_builder.Y(Qubit(2))
+        return circuit_builder.to_circuit()
 
     @pytest.fixture
     def mapping_3(self) -> Mapping:

--- a/test/mapper/test_qubit_remapper.py
+++ b/test/mapper/test_qubit_remapper.py
@@ -10,37 +10,37 @@ from opensquirrel.mapper.qubit_remapper import get_remapped_ir, remap_ir
 class TestRemapper:
     @pytest.fixture
     def circuit_3(self) -> Circuit:
-        circuit_builder = CircuitBuilder(3)
-        circuit_builder.H(Qubit(0))
-        circuit_builder.CNOT(Qubit(0), Qubit(1))
-        circuit_builder.H(Qubit(2))
-        return circuit_builder.to_circuit()
+        builder = CircuitBuilder(3)
+        builder.H(Qubit(0))
+        builder.CNOT(Qubit(0), Qubit(1))
+        builder.H(Qubit(2))
+        return builder.to_circuit()
 
     @pytest.fixture
     def circuit_3_remapped(self) -> Circuit:
-        circuit_builder = CircuitBuilder(3)
-        circuit_builder.H(Qubit(2))
-        circuit_builder.CNOT(Qubit(2), Qubit(1))
-        circuit_builder.H(Qubit(0))
-        return circuit_builder.to_circuit()
+        builder = CircuitBuilder(3)
+        builder.H(Qubit(2))
+        builder.CNOT(Qubit(2), Qubit(1))
+        builder.H(Qubit(0))
+        return builder.to_circuit()
 
     @pytest.fixture
     def circuit_4(self) -> Circuit:
-        circuit_builder = CircuitBuilder(4)
-        circuit_builder.H(Qubit(0))
-        circuit_builder.CNOT(Qubit(0), Qubit(1))
-        circuit_builder.X(Qubit(2))
-        circuit_builder.Y(Qubit(3))
-        return circuit_builder.to_circuit()
+        builder = CircuitBuilder(4)
+        builder.H(Qubit(0))
+        builder.CNOT(Qubit(0), Qubit(1))
+        builder.X(Qubit(2))
+        builder.Y(Qubit(3))
+        return builder.to_circuit()
 
     @pytest.fixture
     def circuit_4_remapped(self) -> Circuit:
-        circuit_builder = CircuitBuilder(4)
-        circuit_builder.H(Qubit(3))
-        circuit_builder.CNOT(Qubit(3), Qubit(1))
-        circuit_builder.X(Qubit(0))
-        circuit_builder.Y(Qubit(2))
-        return circuit_builder.to_circuit()
+        builder = CircuitBuilder(4)
+        builder.H(Qubit(3))
+        builder.CNOT(Qubit(3), Qubit(1))
+        builder.X(Qubit(0))
+        builder.Y(Qubit(2))
+        return builder.to_circuit()
 
     @pytest.fixture
     def mapping_3(self) -> Mapping:

--- a/test/merger/test_merger.py
+++ b/test/merger/test_merger.py
@@ -77,7 +77,7 @@ def test_merge_different_qubits() -> None:
     circuit = builder1.to_circuit()
 
     builder2 = CircuitBuilder(4)
-    builder2.ir.add_gate(BlochSphereRotation(Qubit(0), axis=(1, 0, 1), angle=math.pi))  # This is hadamard with 0 phase
+    builder2.ir.add_gate(BlochSphereRotation(Qubit(0), axis=(1, 0, 1), angle=math.pi))  # this is Hadamard with 0 phase
     builder2.Rz(Qubit(1), Float(1.2345))
     builder2.Ry(Qubit(2), Float(4.234))
     expected_circuit = builder2.to_circuit()

--- a/test/merger/test_merger.py
+++ b/test/merger/test_merger.py
@@ -2,12 +2,10 @@ import math
 from test.ir_equality_test_base import modify_circuit_and_check
 
 from opensquirrel import CircuitBuilder
-from opensquirrel.circuit import Circuit
 from opensquirrel.default_gates import CNOT, Ry, Rz
-from opensquirrel.ir import IR, BlochSphereRotation, Float, Qubit
+from opensquirrel.ir import BlochSphereRotation, Float, Qubit
 from opensquirrel.merger import general_merger
 from opensquirrel.merger.general_merger import compose_bloch_sphere_rotations
-from opensquirrel.register_manager import QubitRegister, RegisterManager
 
 
 def test_compose_bloch_sphere_rotations_same_axis() -> None:
@@ -70,20 +68,19 @@ def test_two_hadamards_different_qubits() -> None:
 
 
 def test_merge_different_qubits() -> None:
-    builder = CircuitBuilder(4)
-    builder.Ry(Qubit(0), Float(math.pi / 2))
-    builder.Rx(Qubit(0), Float(math.pi))
-    builder.Rz(Qubit(1), Float(1.2345))
-    builder.Ry(Qubit(2), Float(1))
-    builder.Ry(Qubit(2), Float(3.234))
-    circuit = builder.to_circuit()
+    builder1 = CircuitBuilder(4)
+    builder1.Ry(Qubit(0), Float(math.pi / 2))
+    builder1.Rx(Qubit(0), Float(math.pi))
+    builder1.Rz(Qubit(1), Float(1.2345))
+    builder1.Ry(Qubit(2), Float(1))
+    builder1.Ry(Qubit(2), Float(3.234))
+    circuit = builder1.to_circuit()
 
-    register_manager = RegisterManager(QubitRegister(4))
-    expected_ir = IR()
-    expected_ir.add_gate(BlochSphereRotation(Qubit(0), axis=(1, 0, 1), angle=math.pi))  # This is hadamard with 0 phase
-    expected_ir.add_gate(Rz(Qubit(1), Float(1.2345)))
-    expected_ir.add_gate(Ry(Qubit(2), Float(4.234)))
-    expected_circuit = Circuit(register_manager, expected_ir)
+    builder2 = CircuitBuilder(4)
+    builder2.ir.add_gate(BlochSphereRotation(Qubit(0), axis=(1, 0, 1), angle=math.pi))  # This is hadamard with 0 phase
+    builder2.Rz(Qubit(1), Float(1.2345))
+    builder2.Ry(Qubit(2), Float(4.234))
+    expected_circuit = builder2.to_circuit()
 
     modify_circuit_and_check(circuit, general_merger.merge_single_qubit_gates, expected_circuit)
 
@@ -94,22 +91,21 @@ def test_merge_different_qubits() -> None:
 
 
 def test_merge_and_flush() -> None:
-    builder = CircuitBuilder(4)
-    builder.Ry(Qubit(0), Float(math.pi / 2))
-    builder.Rz(Qubit(1), Float(1.5))
-    builder.Rx(Qubit(0), Float(math.pi))
-    builder.Rz(Qubit(1), Float(-2.5))
-    builder.CNOT(Qubit(0), Qubit(1))
-    builder.Ry(Qubit(0), Float(3.234))
-    circuit = builder.to_circuit()
+    builder1 = CircuitBuilder(4)
+    builder1.Ry(Qubit(0), Float(math.pi / 2))
+    builder1.Rz(Qubit(1), Float(1.5))
+    builder1.Rx(Qubit(0), Float(math.pi))
+    builder1.Rz(Qubit(1), Float(-2.5))
+    builder1.CNOT(Qubit(0), Qubit(1))
+    builder1.Ry(Qubit(0), Float(3.234))
+    circuit = builder1.to_circuit()
 
-    register_manager = RegisterManager(QubitRegister(4))
-    expected_ir = IR()
-    expected_ir.add_gate(BlochSphereRotation(Qubit(0), axis=(1, 0, 1), angle=math.pi))  # This is hadamard with 0 phase
-    expected_ir.add_gate(Rz(Qubit(1), Float(-1.0)))
-    expected_ir.add_gate(CNOT(Qubit(0), Qubit(1)))
-    expected_ir.add_gate(Ry(Qubit(0), Float(3.234)))
-    expected_circuit = Circuit(register_manager, expected_ir)
+    builder2 = CircuitBuilder(4)
+    builder2.ir.add_gate(BlochSphereRotation(Qubit(0), axis=(1, 0, 1), angle=math.pi))  # This is hadamard with 0 phase
+    builder2.Rz(Qubit(1), Float(-1.0))
+    builder2.CNOT(Qubit(0), Qubit(1))
+    builder2.Ry(Qubit(0), Float(3.234))
+    expected_circuit = builder2.to_circuit()
 
     modify_circuit_and_check(circuit, general_merger.merge_single_qubit_gates, expected_circuit)
 

--- a/test/merger/test_merger.py
+++ b/test/merger/test_merger.py
@@ -101,7 +101,7 @@ def test_merge_and_flush() -> None:
     circuit = builder1.to_circuit()
 
     builder2 = CircuitBuilder(4)
-    builder2.ir.add_gate(BlochSphereRotation(Qubit(0), axis=(1, 0, 1), angle=math.pi))  # This is hadamard with 0 phase
+    builder2.ir.add_gate(BlochSphereRotation(Qubit(0), axis=(1, 0, 1), angle=math.pi))  # this is Hadamard with 0 phase
     builder2.Rz(Qubit(1), Float(-1.0))
     builder2.CNOT(Qubit(0), Qubit(1))
     builder2.Ry(Qubit(0), Float(3.234))

--- a/test/merger/test_merger.py
+++ b/test/merger/test_merger.py
@@ -3,7 +3,7 @@ from test.ir_equality_test_base import modify_circuit_and_check
 
 from opensquirrel import CircuitBuilder
 from opensquirrel.circuit import Circuit
-from opensquirrel.default_gates import CNOT, H, Rx, Ry, Rz
+from opensquirrel.default_gates import CNOT, Ry, Rz
 from opensquirrel.ir import IR, BlochSphereRotation, Float, Qubit
 from opensquirrel.merger import general_merger
 from opensquirrel.merger.general_merger import compose_bloch_sphere_rotations
@@ -120,7 +120,8 @@ def test_merge_and_flush() -> None:
 
 def test_merge_y90_x_to_h() -> None:
     builder = CircuitBuilder(1)
-    builder.Y90(Qubit(0)).X(Qubit(0))
+    builder.Y90(Qubit(0))
+    builder.X(Qubit(0))
     qc = builder.to_circuit()
 
     builder2 = CircuitBuilder(1)

--- a/test/parser/libqasm/test_libqasm.py
+++ b/test/parser/libqasm/test_libqasm.py
@@ -1,6 +1,5 @@
 import pytest
 
-from opensquirrel import Circuit
 from opensquirrel.default_gates import CNOT, CR, CRk, H, I, Ry, X, default_gate_aliases, default_gate_set
 from opensquirrel.ir import Float, Int, Qubit
 from opensquirrel.parser.libqasm.parser import Parser

--- a/test/reindexer/test_qubit_reindexer.py
+++ b/test/reindexer/test_qubit_reindexer.py
@@ -5,7 +5,7 @@ import math
 import numpy as np
 import pytest
 
-from opensquirrel.circuit import Circuit
+from opensquirrel import Circuit, CircuitBuilder
 from opensquirrel.default_gates import Y90, X
 from opensquirrel.ir import IR, Bit, BlochSphereRotation, ControlledGate, Gate, MatrixGate, Measure, Qubit
 from opensquirrel.register_manager import BitRegister, QubitRegister, RegisterManager
@@ -13,10 +13,10 @@ from opensquirrel.reindexer.qubit_reindexer import get_reindexed_circuit
 
 
 def circuit_1_reindexed() -> Circuit:
-    ir = IR()
-    ir.add_gate(Y90(Qubit(1)))
-    ir.add_gate(X(Qubit(0)))
-    return Circuit(RegisterManager(QubitRegister(2)), ir)
+    builder = CircuitBuilder(2)
+    builder.Y90(Qubit(1))
+    builder.X(Qubit(0))
+    return builder.to_circuit()
 
 
 def replacement_gates_1() -> list[Gate]:

--- a/test/reindexer/test_qubit_reindexer.py
+++ b/test/reindexer/test_qubit_reindexer.py
@@ -40,6 +40,7 @@ def circuit_2_reindexed() -> Circuit:
     builder.ir.add_gate(ControlledGate(Qubit(0), X(Qubit(3))))
     return builder.to_circuit()
 
+
 @pytest.mark.parametrize(
     "replacement_gates, qubit_indices, bit_register_size, circuit_reindexed",
     [

--- a/test/reindexer/test_qubit_reindexer.py
+++ b/test/reindexer/test_qubit_reindexer.py
@@ -7,8 +7,7 @@ import pytest
 
 from opensquirrel import Circuit, CircuitBuilder
 from opensquirrel.default_gates import Y90, X
-from opensquirrel.ir import IR, Bit, BlochSphereRotation, ControlledGate, Gate, MatrixGate, Measure, Qubit
-from opensquirrel.register_manager import BitRegister, QubitRegister, RegisterManager
+from opensquirrel.ir import Bit, BlochSphereRotation, ControlledGate, Gate, MatrixGate, Measure, Qubit
 from opensquirrel.reindexer.qubit_reindexer import get_reindexed_circuit
 
 
@@ -33,14 +32,13 @@ def replacement_gates_2() -> list[Gate]:
 
 
 def circuit_2_reindexed() -> Circuit:
-    ir = IR()
-    ir.add_gate(Measure(Qubit(0), Bit(0)))
-    ir.add_gate(BlochSphereRotation(Qubit(2), axis=(0, 0, 1), angle=math.pi))
+    builder = CircuitBuilder(4, 4)
+    builder.measure(Qubit(0), Bit(0))
+    builder.ir.add_gate(BlochSphereRotation(Qubit(2), axis=(0, 0, 1), angle=math.pi))
     matrix = np.array([[1, 0, 0, 0], [0, 0, 1, 0], [0, 1, 0, 0], [0, 0, 0, 1]])
-    ir.add_gate(MatrixGate(matrix, [Qubit(1), Qubit(2)]))
-    ir.add_gate(ControlledGate(Qubit(0), X(Qubit(3))))
-    return Circuit(RegisterManager(QubitRegister(4), BitRegister(4)), ir)
-
+    builder.ir.add_gate(MatrixGate(matrix, [Qubit(1), Qubit(2)]))
+    builder.ir.add_gate(ControlledGate(Qubit(0), X(Qubit(3))))
+    return builder.to_circuit()
 
 @pytest.mark.parametrize(
     "replacement_gates, qubit_indices, bit_register_size, circuit_reindexed",

--- a/test/test_circuit_matrix_calculator.py
+++ b/test/test_circuit_matrix_calculator.py
@@ -2,18 +2,16 @@ import math
 
 import numpy as np
 
-from opensquirrel import circuit_matrix_calculator
-from opensquirrel.circuit import Circuit
+from opensquirrel import Circuit, CircuitBuilder, circuit_matrix_calculator
 from opensquirrel.default_gates import CNOT, H, X
-from opensquirrel.ir import IR, Qubit
+from opensquirrel.ir import Qubit
 from opensquirrel.register_manager import QubitRegister, RegisterManager
 
 
 def test_hadamard() -> None:
-    register_manager = RegisterManager(QubitRegister(1))
-    ir = IR()
-    ir.add_gate(H(Qubit(0)))
-    circuit = Circuit(register_manager, ir)
+    builder = CircuitBuilder(1)
+    builder.H(Qubit(0))
+    circuit = builder.to_circuit()
 
     np.testing.assert_almost_equal(
         circuit_matrix_calculator.get_circuit_matrix(circuit), math.sqrt(0.5) * np.array([[1, 1], [1, -1]])
@@ -21,22 +19,20 @@ def test_hadamard() -> None:
 
 
 def test_double_hadamard() -> None:
-    register_manager = RegisterManager(QubitRegister(1))
-    ir = IR()
-    ir.add_gate(H(Qubit(0)))
-    ir.add_gate(H(Qubit(0)))
-    circuit = Circuit(register_manager, ir)
+    builder = CircuitBuilder(1)
+    builder.H(Qubit(0))
+    builder.H(Qubit(0))
+    circuit = builder.to_circuit()
 
     np.testing.assert_almost_equal(circuit_matrix_calculator.get_circuit_matrix(circuit), np.eye(2))
 
 
 def test_triple_hadamard() -> None:
-    register_manager = RegisterManager(QubitRegister(1))
-    ir = IR()
-    ir.add_gate(H(Qubit(0)))
-    ir.add_gate(H(Qubit(0)))
-    ir.add_gate(H(Qubit(0)))
-    circuit = Circuit(register_manager, ir)
+    builder = CircuitBuilder(1)
+    builder.H(Qubit(0))
+    builder.H(Qubit(0))
+    builder.H(Qubit(0))
+    circuit = builder.to_circuit()
 
     np.testing.assert_almost_equal(
         circuit_matrix_calculator.get_circuit_matrix(circuit), math.sqrt(0.5) * np.array([[1, 1], [1, -1]])
@@ -44,12 +40,10 @@ def test_triple_hadamard() -> None:
 
 
 def test_hadamard_x() -> None:
-    register_manager = RegisterManager(QubitRegister(2))
-    ir = IR()
-    ir.add_gate(H(Qubit(0)))
-    ir.add_gate(X(Qubit(1)))
-    circuit = Circuit(register_manager, ir)
-
+    builder = CircuitBuilder(2)
+    builder.H(Qubit(0))
+    builder.X(Qubit(1))
+    circuit = builder.to_circuit()
     np.testing.assert_almost_equal(
         circuit_matrix_calculator.get_circuit_matrix(circuit),
         math.sqrt(0.5) * np.array([[0, 0, 1, 1], [0, 0, 1, -1], [1, 1, 0, 0], [1, -1, 0, 0]]),
@@ -57,11 +51,10 @@ def test_hadamard_x() -> None:
 
 
 def test_x_hadamard() -> None:
-    register_manager = RegisterManager(QubitRegister(2))
-    ir = IR()
-    ir.add_gate(H(Qubit(1)))
-    ir.add_gate(X(Qubit(0)))
-    circuit = Circuit(register_manager, ir)
+    builder = CircuitBuilder(2)
+    builder.H(Qubit(1))
+    builder.X(Qubit(0))
+    circuit = builder.to_circuit()
 
     np.testing.assert_almost_equal(
         circuit_matrix_calculator.get_circuit_matrix(circuit),
@@ -70,10 +63,9 @@ def test_x_hadamard() -> None:
 
 
 def test_cnot() -> None:
-    register_manager = RegisterManager(QubitRegister(2))
-    ir = IR()
-    ir.add_gate(CNOT(Qubit(1), Qubit(0)))
-    circuit = Circuit(register_manager, ir)
+    builder = CircuitBuilder(2)
+    builder.CNOT(Qubit(1), Qubit(0))
+    circuit = builder.to_circuit()
 
     np.testing.assert_almost_equal(
         circuit_matrix_calculator.get_circuit_matrix(circuit), [[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 0, 1], [0, 0, 1, 0]]
@@ -81,10 +73,9 @@ def test_cnot() -> None:
 
 
 def test_cnot_reversed() -> None:
-    register_manager = RegisterManager(QubitRegister(2))
-    ir = IR()
-    ir.add_gate(CNOT(Qubit(0), Qubit(1)))
-    circuit = Circuit(register_manager, ir)
+    builder = CircuitBuilder(2)
+    builder.CNOT(Qubit(0), Qubit(1))
+    circuit = builder.to_circuit()
 
     np.testing.assert_almost_equal(
         circuit_matrix_calculator.get_circuit_matrix(circuit), [[1, 0, 0, 0], [0, 0, 0, 1], [0, 0, 1, 0], [0, 1, 0, 0]]
@@ -92,11 +83,10 @@ def test_cnot_reversed() -> None:
 
 
 def test_hadamard_cnot() -> None:
-    register_manager = RegisterManager(QubitRegister(2))
-    ir = IR()
-    ir.add_gate(H(Qubit(0)))
-    ir.add_gate(CNOT(Qubit(0), Qubit(1)))
-    circuit = Circuit(register_manager, ir)
+    builder = CircuitBuilder(2)
+    builder.H(Qubit(0))
+    builder.CNOT(Qubit(0), Qubit(1))
+    circuit = builder.to_circuit()
 
     np.testing.assert_almost_equal(
         circuit_matrix_calculator.get_circuit_matrix(circuit),
@@ -105,11 +95,10 @@ def test_hadamard_cnot() -> None:
 
 
 def test_hadamard_cnot_0_2() -> None:
-    register_manager = RegisterManager(QubitRegister(3))
-    ir = IR()
-    ir.add_gate(H(Qubit(0)))
-    ir.add_gate(CNOT(Qubit(0), Qubit(2)))
-    circuit = Circuit(register_manager, ir)
+    builder = CircuitBuilder(3)
+    builder.H(Qubit(0))
+    builder.CNOT(Qubit(0), Qubit(2))
+    circuit = builder.to_circuit()
 
     np.testing.assert_almost_equal(
         circuit_matrix_calculator.get_circuit_matrix(circuit),

--- a/test/test_replacer.py
+++ b/test/test_replacer.py
@@ -5,11 +5,9 @@ import math
 import pytest
 
 from opensquirrel import CircuitBuilder
-from opensquirrel.decomposer import general_decomposer
-from opensquirrel.decomposer.general_decomposer import Decomposer, check_gate_replacement
+from opensquirrel.decomposer.general_decomposer import Decomposer, check_gate_replacement, decompose, replace
 from opensquirrel.default_gates import CNOT, Y90, BlochSphereRotation, H, I, Ry, Rz, X, Z, sqrtSWAP
 from opensquirrel.ir import Float, Gate, Qubit
-from opensquirrel.register_manager import QubitRegister, RegisterManager
 
 
 class TestCheckGateReplacement:
@@ -122,7 +120,7 @@ class TestReplacer:
                     return [I(g.qubit), g, I(g.qubit)]
                 return [g]
 
-        general_decomposer.decompose(circuit.ir, decomposer=TestDecomposer())
+        decompose(circuit.ir, decomposer=TestDecomposer())
 
         builder2 = CircuitBuilder(3)
         builder2.I(Qubit(0))
@@ -139,7 +137,7 @@ class TestReplacer:
         builder1.comment("Test comment.")
         circuit = builder1.to_circuit()
 
-        general_decomposer.replace(circuit.ir, H, lambda q: [Y90(q), X(q)])
+        replace(circuit.ir, H, lambda q: [Y90(q), X(q)])
 
         builder2 = CircuitBuilder(3)
         builder2.Y90(Qubit(0))

--- a/test/test_replacer.py
+++ b/test/test_replacer.py
@@ -4,11 +4,11 @@ import math
 
 import pytest
 
-from opensquirrel.circuit import Circuit
+from opensquirrel import CircuitBuilder
 from opensquirrel.decomposer import general_decomposer
 from opensquirrel.decomposer.general_decomposer import Decomposer, check_gate_replacement
 from opensquirrel.default_gates import CNOT, Y90, BlochSphereRotation, H, I, Ry, Rz, X, Z, sqrtSWAP
-from opensquirrel.ir import IR, Comment, Float, Gate, Qubit
+from opensquirrel.ir import Float, Gate, Qubit
 from opensquirrel.register_manager import QubitRegister, RegisterManager
 
 
@@ -110,43 +110,41 @@ class TestCheckGateReplacement:
 
 class TestReplacer:
     def test_replace_generic(self):
-        register_manager = RegisterManager(QubitRegister(3))
-        ir = IR()
-        ir.add_gate(H(Qubit(0)))
-        ir.add_gate(CNOT(Qubit(0), Qubit(1)))
-        circuit = Circuit(register_manager, ir)
+        builder1 = CircuitBuilder(3)
+        builder1.H(Qubit(0))
+        builder1.CNOT(Qubit(0), Qubit(1))
+        circuit = builder1.to_circuit()
 
         # A simple decomposer function that adds identities before and after single-qubit gates.
         class TestDecomposer(Decomposer):
             def decompose(self, g: Gate) -> list[Gate]:
                 if isinstance(g, BlochSphereRotation):
-                    return [BlochSphereRotation.identity(g.qubit), g, BlochSphereRotation.identity(g.qubit)]
+                    return [I(g.qubit), g, I(g.qubit)]
                 return [g]
 
-        general_decomposer.decompose(ir, decomposer=TestDecomposer())
+        general_decomposer.decompose(circuit.ir, decomposer=TestDecomposer())
 
-        expected_ir = IR()
-        expected_ir.add_gate(BlochSphereRotation.identity(Qubit(0)))
-        expected_ir.add_gate(H(Qubit(0)))
-        expected_ir.add_gate(BlochSphereRotation.identity(Qubit(0)))
-        expected_ir.add_gate(CNOT(Qubit(0), Qubit(1)))
-        expected_circuit = Circuit(register_manager, expected_ir)
+        builder2 = CircuitBuilder(3)
+        builder2.I(Qubit(0))
+        builder2.H(Qubit(0))
+        builder2.I(Qubit(0))
+        builder2.CNOT(Qubit(0), Qubit(1))
+        expected_circuit = builder2.to_circuit()
 
         assert expected_circuit == circuit
 
     def test_replace(self):
-        register_manager = RegisterManager(QubitRegister(3))
-        ir = IR()
-        ir.add_gate(H(Qubit(0)))
-        ir.add_comment(Comment("Test comment."))
-        circuit = Circuit(register_manager, ir)
+        builder1 = CircuitBuilder(3)
+        builder1.H(Qubit(0))
+        builder1.comment("Test comment.")
+        circuit = builder1.to_circuit()
 
-        general_decomposer.replace(ir, H, lambda q: [Y90(q), X(q)])
+        general_decomposer.replace(circuit.ir, H, lambda q: [Y90(q), X(q)])
 
-        expected_ir = IR()
-        expected_ir.add_gate(Y90(Qubit(0)))
-        expected_ir.add_gate(X(Qubit(0)))
-        expected_ir.add_comment(Comment("Test comment."))
-        expected_circuit = Circuit(register_manager, expected_ir)
+        builder2 = CircuitBuilder(3)
+        builder2.Y90(Qubit(0))
+        builder2.X(Qubit(0))
+        builder2.comment("Test comment.")
+        expected_circuit = builder2.to_circuit()
 
         assert expected_circuit == circuit

--- a/test/writer/test_writer.py
+++ b/test/writer/test_writer.py
@@ -1,17 +1,13 @@
 import numpy as np
 
 from opensquirrel import CircuitBuilder
-from opensquirrel.circuit import Circuit
-from opensquirrel.default_gates import CR, H
-from opensquirrel.ir import IR, BlochSphereRotation, Comment, ControlledGate, Float, MatrixGate, Qubit
-from opensquirrel.register_manager import QubitRegister, RegisterManager
+from opensquirrel.ir import BlochSphereRotation, ControlledGate, Float, MatrixGate, Qubit
 from opensquirrel.writer import writer
 
 
 def test_write() -> None:
-    register_manager = RegisterManager(QubitRegister(3))
-    ir = IR()
-    circuit = Circuit(register_manager, ir)
+    builder = CircuitBuilder(3)
+    circuit = builder.to_circuit()
 
     assert (
         writer.circuit_to_string(circuit)
@@ -22,9 +18,9 @@ qubit[3] q
 """
     )
 
-    ir.add_gate(H(Qubit(0)))
-    ir.add_gate(CR(Qubit(0), Qubit(1), Float(1.234)))
-    circuit = Circuit(register_manager, ir)
+    builder.H(Qubit(0))
+    builder.CR(Qubit(0), Qubit(1), Float(1.234))
+    circuit = builder.to_circuit()
 
     assert (
         writer.circuit_to_string(circuit)
@@ -39,14 +35,14 @@ CR(1.234) q[0], q[1]
 
 
 def test_anonymous_gate() -> None:
-    qc = CircuitBuilder(2, 2)
-    qc.H(Qubit(0))
-    qc.ir.add_gate(BlochSphereRotation(Qubit(0), axis=(1, 1, 1), angle=1.23))
-    qc.ir.add_gate(ControlledGate(Qubit(0), BlochSphereRotation(Qubit(0), axis=(1, 1, 1), angle=1.23)))
-    qc.ir.add_gate(MatrixGate(np.array([[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 0, 1], [0, 0, 1, 0]]), [Qubit(0), Qubit(1)]))
-    qc.CR(Qubit(0), Qubit(1), Float(1.234))
+    builder = CircuitBuilder(2, 2)
+    builder.H(Qubit(0))
+    builder.ir.add_gate(BlochSphereRotation(Qubit(0), axis=(1, 1, 1), angle=1.23))
+    builder.ir.add_gate(ControlledGate(Qubit(0), BlochSphereRotation(Qubit(0), axis=(1, 1, 1), angle=1.23)))
+    builder.ir.add_gate(MatrixGate(np.array([[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 0, 1], [0, 0, 1, 0]]), [Qubit(0), Qubit(1)]))
+    builder.CR(Qubit(0), Qubit(1), Float(1.234))
     assert (
-        str(qc.to_circuit())
+        str(builder.to_circuit())
         == """version 3.0
 
 qubit[2] q
@@ -62,13 +58,11 @@ CR(1.234) q[0], q[1]
 
 
 def test_comment() -> None:
-    register_manager = RegisterManager(QubitRegister(3))
-    ir = IR()
-    ir.add_gate(H(Qubit(0)))
-    ir.add_comment(Comment("My comment"))
-    ir.add_gate(CR(Qubit(0), Qubit(1), Float(1.234)))
-    circuit = Circuit(register_manager, ir)
-
+    builder = CircuitBuilder(3)
+    builder.H(Qubit(0))
+    builder.comment("My comment")
+    builder.CR(Qubit(0), Qubit(1), Float(1.234))
+    circuit = builder.to_circuit()
     assert (
         writer.circuit_to_string(circuit)
         == """version 3.0
@@ -85,10 +79,9 @@ CR(1.234) q[0], q[1]
 
 
 def test_cap_significant_digits() -> None:
-    register_manager = RegisterManager(QubitRegister(3))
-    ir = IR()
-    ir.add_gate(CR(Qubit(0), Qubit(1), Float(1.6546514861321684321654)))
-    circuit = Circuit(register_manager, ir)
+    builder = CircuitBuilder(3)
+    builder.CR(Qubit(0), Qubit(1), Float(1.6546514861321684321654))
+    circuit = builder.to_circuit()
 
     assert (
         writer.circuit_to_string(circuit)

--- a/test/writer/test_writer.py
+++ b/test/writer/test_writer.py
@@ -39,7 +39,9 @@ def test_anonymous_gate() -> None:
     builder.H(Qubit(0))
     builder.ir.add_gate(BlochSphereRotation(Qubit(0), axis=(1, 1, 1), angle=1.23))
     builder.ir.add_gate(ControlledGate(Qubit(0), BlochSphereRotation(Qubit(0), axis=(1, 1, 1), angle=1.23)))
-    builder.ir.add_gate(MatrixGate(np.array([[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 0, 1], [0, 0, 1, 0]]), [Qubit(0), Qubit(1)]))
+    builder.ir.add_gate(
+        MatrixGate(np.array([[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 0, 1], [0, 0, 1, 0]]), [Qubit(0), Qubit(1)])
+    )
     builder.CR(Qubit(0), Qubit(1), Float(1.234))
     assert (
         str(builder.to_circuit())


### PR DESCRIPTION
All test that can use the `CircuitBuilder` now use the `CircuitBuilder` to build the circuits required for the tests.

The following tests were left untouched:
- Integration test
- Parser tests
- Measurement tests. Some of these tests are checking checking parsing of measurements from string (we might want to move those to the parsing tests)
- Register test. Named registers are not supported in the `CircuitBuilder`.

