### PR TITLE
Cqt 76 linked ir between circuit and circuit builder

### DIFF
--- a/opensquirrel/circuit_builder.py
+++ b/opensquirrel/circuit_builder.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import inspect
 from collections.abc import Callable, Mapping
+from copy import deepcopy
 from functools import partial
 from typing import Any
 
@@ -124,4 +125,4 @@ class CircuitBuilder(GateLibrary, MeasurementLibrary):
                 self._check_bit_out_of_bounds_access(args[i].index)
 
     def to_circuit(self) -> Circuit:
-        return Circuit(self.register_manager, self.ir)
+        return Circuit(deepcopy(self.register_manager), deepcopy(self.ir))

--- a/test/test_circuit_builder.py
+++ b/test/test_circuit_builder.py
@@ -121,5 +121,5 @@ class TestCircuitBuilder:
     def test_decoupling_circuit_and_builder(self) -> None:
         builder = CircuitBuilder(1)
         circuit = builder.to_circuit()
-        builder.I(Qubit(0))
-        assert len(circuit.ir.statements) == 0
+        assert circuit.ir is not builder.ir
+        assert circuit.register_manager is not builder.register_manager

--- a/test/test_circuit_builder.py
+++ b/test/test_circuit_builder.py
@@ -117,3 +117,9 @@ class TestCircuitBuilder:
             "wrong argument type for instruction `H`, got <class 'int'> but expected Qubit",
             str(exception_info.value),
         )
+    
+    def test_decoupling_circuit_and_builder(self) -> None:
+        builder = CircuitBuilder(1)
+        circuit = builder.to_circuit()
+        builder.I(Qubit(0))
+        assert len(circuit.ir.statements) == 0

--- a/test/test_circuit_builder.py
+++ b/test/test_circuit_builder.py
@@ -117,7 +117,7 @@ class TestCircuitBuilder:
             "wrong argument type for instruction `H`, got <class 'int'> but expected Qubit",
             str(exception_info.value),
         )
-    
+
     def test_decoupling_circuit_and_builder(self) -> None:
         builder = CircuitBuilder(1)
         circuit = builder.to_circuit()


### PR DESCRIPTION
Use `deepcopy` to copy the `IR` and `RegisterManager` of the builder instead of using a reference.
Added a test for this behavior as well.