### PR TITLE
CQT 39: check if ANTLR4 dependency is still required (otherwise, remove)

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -38,17 +38,6 @@ files = [
 typing-extensions = {version = ">=4.0.0", markers = "python_version < \"3.9\""}
 
 [[package]]
-name = "antlr4-python3-runtime"
-version = "4.13.1"
-description = "ANTLR 4.13.1 runtime for Python 3"
-optional = false
-python-versions = "*"
-files = [
-    {file = "antlr4-python3-runtime-4.13.1.tar.gz", hash = "sha256:3cd282f5ea7cfb841537fe01f143350fdb1c0b1ce7981443a2fa8513fddb6d1a"},
-    {file = "antlr4_python3_runtime-4.13.1-py3-none-any.whl", hash = "sha256:78ec57aad12c97ac039ca27403ad61cb98aaec8a3f9bb8144f889aa0fa28b943"},
-]
-
-[[package]]
 name = "appnope"
 version = "0.1.4"
 description = "Disable App Nap on macOS >= 10.9"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,6 @@ packages = [
 
 [tool.poetry.dependencies]
 python = "^3.8"
-antlr4-python3-runtime = "^4.13.1"
 numpy = [
     { version = "1.24", python = "<3.9" },
     { version = "^1.26", python = "^3.9" },
@@ -80,7 +79,7 @@ asyncio_mode = "auto"
 
 [tool.coverage.run]
 branch = true
-omit = ["tests/*", "**/.tox/**", "opensquirrel/parsing/antlr/generated/*"]
+omit = ["tests/*", "**/.tox/**"]
 
 [tool.coverage.report]
 show_missing = true


### PR DESCRIPTION
Remove ANTLR4 dependency.