### PR TITLE
[CQT-50] Add extra tests to writers where needed

### DIFF
--- a/opensquirrel/writer/writer.py
+++ b/opensquirrel/writer/writer.py
@@ -4,6 +4,7 @@ from opensquirrel.register_manager import RegisterManager
 
 
 class _WriterImpl(IRVisitor):
+    # Precision used when writing out a float number
     FLOAT_PRECISION = 8
 
     def __init__(self, register_manager: RegisterManager) -> None:

--- a/opensquirrel/writer/writer.py
+++ b/opensquirrel/writer/writer.py
@@ -64,4 +64,4 @@ def circuit_to_string(circuit: Circuit) -> str:
 
     circuit.ir.accept(writer_impl)
 
-    return writer_impl.output.rstrip() + "\n"  # remove all trailing lines, and leave only one
+    return writer_impl.output.rstrip() + "\n"  # remove all trailing lines and leave only one

--- a/opensquirrel/writer/writer.py
+++ b/opensquirrel/writer/writer.py
@@ -63,8 +63,4 @@ def circuit_to_string(circuit: Circuit) -> str:
 
     circuit.ir.accept(writer_impl)
 
-    return (
-        writer_impl.output
-        .rstrip()  # remove all trailing lines
-        + '\n'  # and leave only one
-    )
+    return writer_impl.output.rstrip() + "\n"  # remove all trailing lines, and leave only one

--- a/opensquirrel/writer/writer.py
+++ b/opensquirrel/writer/writer.py
@@ -4,7 +4,7 @@ from opensquirrel.register_manager import RegisterManager
 
 
 class _WriterImpl(IRVisitor):
-    number_of_significant_digits = 8
+    FLOAT_PRECISION = 8
 
     def __init__(self, register_manager: RegisterManager) -> None:
         self.register_manager = register_manager
@@ -29,7 +29,7 @@ class _WriterImpl(IRVisitor):
         return f"{i.value}"
 
     def visit_float(self, f: Float) -> str:
-        return f"{f.value:.{self.number_of_significant_digits}}"
+        return f"{f.value:.{self.FLOAT_PRECISION}}"
 
     def visit_measure(self, measure: Measure) -> None:
         if measure.is_abstract:
@@ -63,4 +63,8 @@ def circuit_to_string(circuit: Circuit) -> str:
 
     circuit.ir.accept(writer_impl)
 
-    return writer_impl.output
+    return (
+        writer_impl.output
+        .rstrip()  # remove all trailing lines
+        + '\n'  # and leave only one
+    )

--- a/test/writer/test_writer.py
+++ b/test/writer/test_writer.py
@@ -1,27 +1,27 @@
 import numpy as np
 
 from opensquirrel import CircuitBuilder
-from opensquirrel.ir import BlochSphereRotation, ControlledGate, Float, MatrixGate, Qubit
+from opensquirrel.ir import Bit, BlochSphereRotation, ControlledGate, Float, MatrixGate, Qubit
 from opensquirrel.writer import writer
 
 
-def test_write() -> None:
+def test_circuit_without_bits() -> None:
     builder = CircuitBuilder(3)
     circuit = builder.to_circuit()
-
     assert (
         writer.circuit_to_string(circuit)
         == """version 3.0
 
 qubit[3] q
-
 """
     )
 
+
+def test_circuit_with_qubits_and_bits() -> None:
+    builder = CircuitBuilder(3)
     builder.H(Qubit(0))
     builder.CR(Qubit(0), Qubit(1), Float(1.234))
     circuit = builder.to_circuit()
-
     assert (
         writer.circuit_to_string(circuit)
         == """version 3.0
@@ -30,6 +30,65 @@ qubit[3] q
 
 H q[0]
 CR(1.234) q[0], q[1]
+"""
+    )
+
+
+def test_circuit_to_string_after_circuit_modification() -> None:
+    builder = CircuitBuilder(3)
+    circuit = builder.to_circuit()
+    assert (
+        writer.circuit_to_string(circuit)
+        == """version 3.0
+
+qubit[3] q
+"""
+    )
+
+    builder.H(Qubit(0))
+    builder.CR(Qubit(0), Qubit(1), Float(1.234))
+    circuit = builder.to_circuit()
+    assert (
+        writer.circuit_to_string(circuit)
+        == """version 3.0
+
+qubit[3] q
+
+H q[0]
+CR(1.234) q[0], q[1]
+"""
+    )
+
+
+def test_float_precision() -> None:
+    builder = CircuitBuilder(3)
+    builder.CR(Qubit(0), Qubit(1), Float(1.6546514861321684321654))
+    circuit = builder.to_circuit()
+    assert (
+        writer.circuit_to_string(circuit)
+        == """version 3.0
+
+qubit[3] q
+
+CR(1.6546515) q[0], q[1]
+"""
+    )
+
+
+def test_measure() -> None:
+    builder = CircuitBuilder(1, 1)
+    builder.H(Qubit(0))
+    builder.measure(Qubit(0), Bit(0))
+    circuit = builder.to_circuit()
+    assert (
+        writer.circuit_to_string(circuit)
+        == """version 3.0
+
+qubit[1] q
+bit[1] b
+
+H q[0]
+b[0] = measure q[0]
 """
     )
 
@@ -76,21 +135,5 @@ H q[0]
 /* My comment */
 
 CR(1.234) q[0], q[1]
-"""
-    )
-
-
-def test_cap_significant_digits() -> None:
-    builder = CircuitBuilder(3)
-    builder.CR(Qubit(0), Qubit(1), Float(1.6546514861321684321654))
-    circuit = builder.to_circuit()
-
-    assert (
-        writer.circuit_to_string(circuit)
-        == """version 3.0
-
-qubit[3] q
-
-CR(1.6546515) q[0], q[1]
 """
     )

--- a/test/writer/test_writer.py
+++ b/test/writer/test_writer.py
@@ -18,18 +18,14 @@ qubit[3] q
 
 
 def test_circuit_with_qubits_and_bits() -> None:
-    builder = CircuitBuilder(3)
-    builder.H(Qubit(0))
-    builder.CR(Qubit(0), Qubit(1), Float(1.234))
+    builder = CircuitBuilder(3, 3)
     circuit = builder.to_circuit()
     assert (
         writer.circuit_to_string(circuit)
         == """version 3.0
 
 qubit[3] q
-
-H q[0]
-CR(1.234) q[0], q[1]
+bit[3] b
 """
     )
 


### PR DESCRIPTION
Add a few tests.
Rename also some tests.
Rename `num_significant_digits` to `FLOAT_PRECISION` (for consistency with Quantify Scheduler exporter's `DEG_PRECISION`).
Change writer to always only output one single trailing newline.