### PR TITLE
[CQT-101] Fix bug where target and control qubits can be the same

### DIFF
--- a/opensquirrel/ir.py
+++ b/opensquirrel/ir.py
@@ -279,6 +279,18 @@ class Gate(Statement, ABC):
     def is_anonymous(self) -> bool:
         return self.arguments is None
 
+    @staticmethod
+    def _check_repeated_qubit_operands(qubits: list[Qubit]) -> bool:
+        """Check if qubit operands are repeated.
+
+        Args:
+            qubits: List of qubits.
+
+        Returns:
+            Whether qubit operands are repeated.
+        """
+        return len(qubits) != len(set(qubits))
+
     @abstractmethod
     def get_qubit_operands(self) -> list[Qubit]:
         """Get the qubit operands of the Gate.
@@ -362,6 +374,9 @@ class MatrixGate(Gate):
         if len(operands) < 2:
             raise ValueError("for 1q gates, please use BlochSphereRotation")
 
+        if self._check_repeated_qubit_operands(operands):
+            raise ValueError("control and target cannot be the same qubit")
+
         if matrix.shape != (1 << len(operands), 1 << len(operands)):
             raise ValueError(
                 f"incorrect matrix shape. "
@@ -396,6 +411,9 @@ class ControlledGate(Gate):
         Gate.__init__(self, generator, arguments)
         self.control_qubit = control_qubit
         self.target_gate = target_gate
+
+        if self._check_repeated_qubit_operands([control_qubit] + target_gate.get_qubit_operands()):
+            raise ValueError("control and target cannot be the same qubit")
 
     def __repr__(self) -> str:
         return f"ControlledGate(control_qubit={self.control_qubit}, {self.target_gate})"

--- a/test/test_ir.py
+++ b/test/test_ir.py
@@ -263,3 +263,17 @@ class TestMatrixGate:
     def test_is_identity(self, gate: MatrixGate) -> None:
         assert MatrixGate(np.eye(4), operands=[Qubit(42), Qubit(100)]).is_identity()
         assert not gate.is_identity()
+
+    def test_matrix_gate_same_control_and_target_qubit(self) -> None:
+        with pytest.raises(ValueError) as e_info:
+            MatrixGate(np.eye(4), [Qubit(0), Qubit(0)])
+
+        assert "control and target cannot be the same qubit" in str(e_info.value)
+
+
+class TestControlledGate:
+    def test_control_gate_same_control_and_target_qubit(self) -> None:
+        with pytest.raises(ValueError) as e_info:
+            ControlledGate(Qubit(0), BlochSphereRotation(Qubit(0), [0, 0, 1], angle=np.pi))
+
+        assert "control and target cannot be the same qubit" in str(e_info.value)

--- a/test/writer/test_writer.py
+++ b/test/writer/test_writer.py
@@ -38,7 +38,7 @@ def test_anonymous_gate() -> None:
     builder = CircuitBuilder(2, 2)
     builder.H(Qubit(0))
     builder.ir.add_gate(BlochSphereRotation(Qubit(0), axis=(1, 1, 1), angle=1.23))
-    builder.ir.add_gate(ControlledGate(Qubit(0), BlochSphereRotation(Qubit(0), axis=(1, 1, 1), angle=1.23)))
+    builder.ir.add_gate(ControlledGate(Qubit(0), BlochSphereRotation(Qubit(1), axis=(1, 1, 1), angle=1.23)))
     builder.ir.add_gate(
         MatrixGate(np.array([[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 0, 1], [0, 0, 1, 0]]), [Qubit(0), Qubit(1)])
     )
@@ -52,7 +52,7 @@ bit[2] b
 
 H q[0]
 Anonymous gate: BlochSphereRotation(Qubit[0], axis=[0.57735 0.57735 0.57735], angle=1.23, phase=0.0)
-Anonymous gate: ControlledGate(control_qubit=Qubit[0], BlochSphereRotation(Qubit[0], axis=[0.57735 0.57735 0.57735], angle=1.23, phase=0.0))
+Anonymous gate: ControlledGate(control_qubit=Qubit[0], BlochSphereRotation(Qubit[1], axis=[0.57735 0.57735 0.57735], angle=1.23, phase=0.0))
 Anonymous gate: MatrixGate(qubits=[Qubit[0], Qubit[1]], matrix=[[1 0 0 0] [0 1 0 0] [0 0 0 1] [0 0 1 0]])
 CR(1.234) q[0], q[1]
 """


### PR DESCRIPTION
- Added private static method to check MatrixGate & ControlledGate classes
- Added tests
- Fixed failing tests