### PR TITLE
Switch from Default Analyzer

### DIFF
--- a/opensquirrel/parser/libqasm/parser.py
+++ b/opensquirrel/parser/libqasm/parser.py
@@ -160,12 +160,6 @@ class Parser(GateLibrary, MeasurementLibrary):
         raise TypeError("unsupported type")
 
     def _create_analyzer(self) -> cqasm.Analyzer:
-        # TODO: we are temporarily using the default analyzer,
-        #   mainly because there is a misalignment between the AST and the IR measure nodes.
-        #   The AST currently produces measure nodes with a bit argument,
-        #   but the IR doesn't consider yet that bit argument.
-        #   In the future, we may want to go back to no using the default analyzer again,
-        #   so that all gates are registered based on OpenSquirrel's default gate set
         without_defaults = False
         analyzer = cqasm.Analyzer("3.0", without_defaults)
         return analyzer


### PR DESCRIPTION
Instead of switching from the default analyzer, we keep registering the instructions in libQASM and also have them in the OpenSquirrel gate/measurement libraries.

- Removed the TODO in the `_create_analyzer` method in the module `parser.py`.