### PR TITLE
[CQT-167] Remove asyncio mode

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,7 +85,6 @@ quantify-scheduler=[
 
 [tool.pytest.ini_options]
 addopts = "-v --cov --cov-report term-missing:skip-covered --cov-report xml"
-asyncio_mode = "auto"
 
 [tool.coverage.run]
 branch = true


### PR DESCRIPTION
Asyncio mode not needed as it determines the default event loop scope of asynchronous fixtures.