### PR TITLE
[CQT 126] Verify dataclasses using __post_init__ (#319)

### DIFF
--- a/opensquirrel/ir.py
+++ b/opensquirrel/ir.py
@@ -5,7 +5,7 @@ from abc import ABC, abstractmethod
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass
 from functools import wraps
-from typing import Any, Union, cast, overload
+from typing import Any, SupportsFloat, SupportsInt, Union, cast, overload
 
 import numpy as np
 from numpy.typing import ArrayLike, DTypeLike, NDArray
@@ -76,6 +76,13 @@ class Float(Expression):
     def accept(self, visitor: IRVisitor) -> Any:
         return visitor.visit_float(self)
 
+    def __post_init__(self) -> None:
+        if isinstance(self.value, SupportsFloat):
+            self.value = float(self.value)
+        else:
+            msg = "value must be a float"
+            raise TypeError(msg)
+
 
 @dataclass
 class Int(Expression):
@@ -83,6 +90,13 @@ class Int(Expression):
 
     def accept(self, visitor: IRVisitor) -> Any:
         return visitor.visit_int(self)
+
+    def __post_init__(self) -> None:
+        if isinstance(self.value, SupportsInt):
+            self.value = int(self.value)
+        else:
+            msg = "value must be an int"
+            raise TypeError(msg)
 
 
 @dataclass
@@ -94,6 +108,13 @@ class Bit(Expression):
 
     def __repr__(self) -> str:
         return f"Bit[{self.index}]"
+
+    def __post_init__(self) -> None:
+        if isinstance(self.index, SupportsInt):
+            self.index = int(self.index)
+        else:
+            msg = "index must be an int"
+            raise TypeError(msg)
 
     def accept(self, visitor: IRVisitor) -> Any:
         return visitor.visit_bit(self)
@@ -108,6 +129,13 @@ class Qubit(Expression):
 
     def __repr__(self) -> str:
         return f"Qubit[{self.index}]"
+
+    def __post_init__(self) -> None:
+        if isinstance(self.index, SupportsInt):
+            self.index = int(self.index)
+        else:
+            msg = "index must be an int"
+            raise TypeError(msg)
 
     def accept(self, visitor: IRVisitor) -> Any:
         return visitor.visit_qubit(self)

--- a/test/test_ir.py
+++ b/test/test_ir.py
@@ -9,7 +9,18 @@ import pytest
 from numpy.typing import ArrayLike
 
 from opensquirrel.common import ATOL
-from opensquirrel.ir import Axis, Bit, BlochSphereRotation, ControlledGate, Expression, MatrixGate, Measure, Qubit
+from opensquirrel.ir import (
+    Axis,
+    Bit,
+    BlochSphereRotation,
+    ControlledGate,
+    Expression,
+    Float,
+    Int,
+    MatrixGate,
+    Measure,
+    Qubit,
+)
 
 
 class TestAxis:
@@ -297,3 +308,39 @@ class TestControlledGate:
     def test_control_gate_same_control_and_target_qubit(self) -> None:
         with pytest.raises(ValueError, match="control and target qubit cannot be the same"):
             ControlledGate(Qubit(0), BlochSphereRotation(Qubit(0), [0, 0, 1], angle=np.pi))
+
+
+class TestFloat:
+    def test_type_error(self) -> None:
+        with pytest.raises(TypeError, match="value must be a float"):
+            Float("f")  # type: ignore
+
+    def test_init(self) -> None:
+        assert Float(1).value == 1.0
+
+
+class TestInt:
+    def test_type_error(self) -> None:
+        with pytest.raises(TypeError, match="value must be an int"):
+            Int("f")  # type: ignore
+
+    def test_init(self) -> None:
+        assert Int(1).value == 1
+
+
+class TestBit:
+    def test_type_error(self) -> None:
+        with pytest.raises(TypeError, match="index must be an int"):
+            Bit("f")  # type: ignore
+
+    def test_init(self) -> None:
+        assert str(Bit(1)) == "Bit[1]"
+
+
+class TestQubit:
+    def test_type_error(self) -> None:
+        with pytest.raises(TypeError, match="index must be an int"):
+            Qubit("f")  # type: ignore
+
+    def test_init(self) -> None:
+        assert str(Qubit(1)) == "Qubit[1]"


### PR DESCRIPTION
* Verify dataclasses using __post_init__

* Restructure tests and remove try-exceptions

* Fix typos

---------