### PR TITLE
[CQT-166] Review required dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -176,9 +176,6 @@ flake8-type-checking.exempt-modules = ["typing", "typing_extensions", "numpy", "
     "SLF001", # Checking private functions is ok
 ]
 
-[tool.black]
-line-length = 120
-
 [tool.mypy]
 ignore_missing_imports = true
 strict = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,6 @@ libqasm = "0.6.7"
 networkx = "^3.0.0"
 
 [tool.poetry.group.dev.dependencies]
-black = {extras = ["jupyter"], version = ">=23.11,<25.0"}
 coverage = {extras = ["toml"], version = "^7.3.2"}
 pytest = {extras = ["toml"], version = ">=7.4.3,<9.0.0"}
 pytest-cov = ">=4.1,<6.0"
@@ -57,7 +56,6 @@ mkdocs_gen_files = {extras = ["python"], version = "^0.5.0"}
 mkdocs-material = "^9.4.12"
 mkdocs-literate-nav = "^0.6.1"
 pymdown-extensions = "^10.7.1"
-sympy = "^1.13.1"
 
 [tool.poetry.group.examples]
 optional = true

--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,6 @@ commands_pre =
 [testenv:lint]
 description = run linters
 commands =
-    poetry run black --check .
     poetry run ruff check
 
 [testenv:type]


### PR DESCRIPTION
- Removed `black` from the `pyproject.toml` and `tox.ini` files.
- Removed `sympy` from the `docs` group

The `IPython` and `sympy` packages are necessary in the `dev` group as they are used to test the examples.