### PR TITLE
[CQT 201] Incorrect hashing of qubit

### DIFF
--- a/opensquirrel/ir.py
+++ b/opensquirrel/ir.py
@@ -124,7 +124,7 @@ class Bit(Expression):
     index: int
 
     def __hash__(self) -> int:
-        return hash(self.index)
+        return hash(str(self.__class__) + str(self.index))
 
     def __repr__(self) -> str:
         return f"Bit[{self.index}]"
@@ -145,7 +145,7 @@ class Qubit(Expression):
     index: int
 
     def __hash__(self) -> int:
-        return hash(self.index)
+        return hash(str(self.__class__) + str(self.index))
 
     def __repr__(self) -> str:
         return f"Qubit[{self.index}]"

--- a/test/test_ir.py
+++ b/test/test_ir.py
@@ -183,6 +183,9 @@ class TestIR:
 
         assert cnot_controlled_gate != swap_matrix_gate
 
+    def test_hash_difference_bit_qubit(self) -> None:
+        assert hash(Qubit(1)) != hash(Bit(1))
+
 
 class TestMeasure:
     @pytest.fixture(name="measure")


### PR DESCRIPTION
- Hashing of qubit and bit are no longer the same
- hash(Qubit(1)) != hash(Bit(1))