### PR TITLE
CQT-153 implement open squirrel release procedure

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,6 +17,6 @@ jobs:
       - name: Build and publish to Test PyPI
         uses: JRubics/poetry-publish@v2.0
         with:
-          pypi_token: ${{ secrets.TEST_PYPI_TOKEN }}
+          pypi_token: ${{ secrets.TEST_PYPI_API_TOKEN }}
           repository_name: "testpypi"
           repository_url: "https://test.pypi.org/legacy/"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,22 @@
+name: Release
+
+on:
+  release:
+    types:
+      - created
+
+jobs:
+  pypi-publish:
+    name: Upload release to PyPI
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      # TODO: change to PyPI proper (i.e. not TestPyPI)
+      - name: Build and publish to Test PyPI
+        uses: JRubics/poetry-publish@v2.0
+        with:
+          pypi_token: ${{ secrets.TEST_PYPI_TOKEN }}
+          repository_name: "testpypi"
+          repository_url: "https://test.pypi.org/legacy/"


### PR DESCRIPTION
- Implemented the .github/workflows/release.yaml
  - For now the release procedure published to __Test PyPI__, this should be changed to __PyPI__ when deemed ready.
    - `name` needs to be changed to `Build and publish to PyPI`
    - `pypi_token` needs to be changed to `${{ secrets.PYPI_API_TOKEN }}`
    - The token needs to be added to the GitHub Action environment secrets, under the environment `production` and name `PYPI_API_TOKEN`
    - The fields `repository_name` and `repository_url` should be removed
- [[CQT-152](https://qutech-sd.atlassian.net/browse/CQT-152)] needs to be reviewed and resolved __first__, as it will likely impose changes to this current implementation of the release procedure.

[CQT-152]: https://qutech-sd.atlassian.net/browse/CQT-152?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ