### PR TITLE
Remove unsupported gates from default gate set.

### DIFF
--- a/opensquirrel/default_gates.py
+++ b/opensquirrel/default_gates.py
@@ -4,9 +4,7 @@ import math
 from collections.abc import Callable
 from typing import SupportsInt
 
-import numpy as np
-
-from opensquirrel.ir import BlochSphereRotation, ControlledGate, Float, Gate, Int, MatrixGate, QubitLike, named_gate
+from opensquirrel.ir import BlochSphereRotation, ControlledGate, Float, Gate, Int, QubitLike, named_gate
 
 
 @named_gate
@@ -113,41 +111,6 @@ def CRk(control: QubitLike, target: QubitLike, k: SupportsInt) -> ControlledGate
     return ControlledGate(control, BlochSphereRotation(qubit=target, axis=(0, 0, 1), angle=theta, phase=theta / 2))
 
 
-@named_gate
-def SWAP(q1: QubitLike, q2: QubitLike) -> MatrixGate:
-    return MatrixGate(
-        np.array(
-            [
-                [1, 0, 0, 0],
-                [0, 0, 1, 0],
-                [0, 1, 0, 0],
-                [0, 0, 0, 1],
-            ],
-        ),
-        [q1, q2],
-    )
-
-
-@named_gate
-def sqrtSWAP(q1: QubitLike, q2: QubitLike) -> MatrixGate:
-    return MatrixGate(
-        np.array(
-            [
-                [1, 0, 0, 0],
-                [0, (1 + 1j) / 2, (1 - 1j) / 2, 0],
-                [0, (1 - 1j) / 2, (1 + 1j) / 2, 0],
-                [0, 0, 0, 1],
-            ],
-        ),
-        [q1, q2],
-    )
-
-
-@named_gate
-def CCZ(control1: QubitLike, control2: QubitLike, target: QubitLike) -> ControlledGate:
-    return ControlledGate(control1, CZ(control2, target))
-
-
 default_bloch_sphere_rotations_without_params: list[Callable[[QubitLike], BlochSphereRotation]]
 default_bloch_sphere_rotations_without_params = [
     I,
@@ -180,9 +143,6 @@ default_gate_set = [
     CZ,
     CR,
     CRk,
-    SWAP,
-    sqrtSWAP,
-    CCZ,
 ]
 
 default_gate_aliases = {

--- a/test/decomposer/test_cnot_decomposer.py
+++ b/test/decomposer/test_cnot_decomposer.py
@@ -6,7 +6,7 @@ import pytest
 
 from opensquirrel.decomposer.cnot_decomposer import CNOTDecomposer
 from opensquirrel.decomposer.general_decomposer import check_gate_replacement
-from opensquirrel.default_gates import CNOT, CZ, SWAP, H, Ry, Rz, X
+from opensquirrel.default_gates import CNOT, CZ, H, Ry, Rz, X
 from opensquirrel.ir import ControlledGate, Float, Gate
 
 
@@ -22,13 +22,6 @@ def decomposer_fixture() -> CNOTDecomposer:
 def test_ignores_1q_gates(decomposer: CNOTDecomposer, gate: Gate, expected_result: list[Gate]) -> None:
     check_gate_replacement(gate, expected_result)
     assert decomposer.decompose(gate) == expected_result
-
-
-def test_ignores_matrix_gate(decomposer: CNOTDecomposer) -> None:
-    gate = SWAP(4, 3)
-    decomposed_gate = decomposer.decompose(gate)
-    check_gate_replacement(gate, decomposed_gate)
-    assert decomposed_gate == [gate]
 
 
 def test_ignores_double_controlled(decomposer: CNOTDecomposer) -> None:

--- a/test/exporter/test_quantify_scheduler_exporter.py
+++ b/test/exporter/test_quantify_scheduler_exporter.py
@@ -11,7 +11,7 @@ import pytest
 
 from opensquirrel import CircuitBuilder
 from opensquirrel.common import ATOL
-from opensquirrel.default_gates import CCZ, SWAP, H
+from opensquirrel.default_gates import H
 from opensquirrel.exceptions import ExporterError
 from opensquirrel.exporter import quantify_scheduler_exporter
 from opensquirrel.exporter.quantify_scheduler_exporter import FIXED_POINT_DEG_PRECISION
@@ -87,8 +87,8 @@ class TestQuantifySchedulerExporter:
 
     @pytest.mark.parametrize(
         "gate",
-        [H(0), SWAP(0, 1), BlochSphereRotation(qubit=0, axis=(1, 2, 3), angle=0.9876, phase=2.34), CCZ(0, 1, 2)],
-        ids=["H", "SWAP", "BSR", "CCZ"],
+        [H(0), BlochSphereRotation(qubit=0, axis=(1, 2, 3), angle=0.9876, phase=2.34)],
+        ids=["H", "BSR"],
     )
     def test_gates_not_supported(self, gate: Gate) -> None:
         builder = CircuitBuilder(3)

--- a/test/test_replacer.py
+++ b/test/test_replacer.py
@@ -1,14 +1,12 @@
 from __future__ import annotations
 
-import math
-
 import pytest
 
 from opensquirrel import CircuitBuilder
 from opensquirrel.decomposer import Decomposer
 from opensquirrel.decomposer.general_decomposer import check_gate_replacement, decompose, replace
-from opensquirrel.default_gates import CNOT, Y90, H, I, Ry, Rz, X, Z, sqrtSWAP
-from opensquirrel.ir import BlochSphereRotation, Float, Gate
+from opensquirrel.default_gates import CNOT, Y90, H, I, X
+from opensquirrel.ir import BlochSphereRotation, Gate
 
 
 class TestCheckGateReplacement:
@@ -39,50 +37,6 @@ class TestCheckGateReplacement:
         with pytest.raises(ValueError, match=error_msg):
             check_gate_replacement(gate, replacement_gates)
 
-    def test_cnot_as_sqrt_swap(self) -> None:
-        # https://en.wikipedia.org/wiki/Quantum_logic_gate#/media/File:Qcircuit_CNOTsqrtSWAP2.svg
-        c = 0
-        t = 1
-        check_gate_replacement(
-            CNOT(control=c, target=t),
-            [
-                Ry(t, Float(math.pi / 2)),
-                sqrtSWAP(c, t),
-                Z(c),
-                sqrtSWAP(c, t),
-                Rz(c, Float(-math.pi / 2)),
-                Rz(t, Float(-math.pi / 2)),
-                Ry(t, Float(-math.pi / 2)),
-            ],
-        )
-
-        with pytest.raises(ValueError, match="replacement for gate CNOT does not preserve the quantum state"):
-            check_gate_replacement(
-                CNOT(control=c, target=t),
-                [
-                    Ry(t, Float(math.pi / 2)),
-                    sqrtSWAP(c, t),
-                    Z(c),
-                    sqrtSWAP(c, t),
-                    Rz(c, Float(-math.pi / 2 + 0.01)),
-                    Rz(t, Float(-math.pi / 2)),
-                    Ry(t, Float(-math.pi / 2)),
-                ],
-            )
-
-        with pytest.raises(ValueError, match="replacement for gate CNOT does not seem to operate on the right qubits"):
-            check_gate_replacement(
-                CNOT(control=c, target=t),
-                [
-                    Ry(t, Float(math.pi / 2)),
-                    sqrtSWAP(c, t),
-                    Z(c),
-                    sqrtSWAP(c, 2),
-                    Rz(c, Float(-math.pi / 2 + 0.01)),
-                    Rz(t, Float(-math.pi / 2)),
-                    Ry(t, Float(-math.pi / 2)),
-                ],
-            )
 
     def test_large_number_of_qubits(self) -> None:
         # If we were building the whole circuit matrix, this would run out of memory.


### PR DESCRIPTION
- Removed SWAP, sqrtSWAP, and CCZ from the `default_gates.py`
- Removed tests specifically involving these gates