### PR TITLE
Fix PEP8 naming

### DIFF
--- a/opensquirrel/circuit_builder.py
+++ b/opensquirrel/circuit_builder.py
@@ -13,16 +13,7 @@ from opensquirrel.default_gates import default_gate_aliases, default_gate_set
 from opensquirrel.default_measures import default_measure_set
 from opensquirrel.default_resets import default_reset_set
 from opensquirrel.instruction_library import GateLibrary, MeasureLibrary, ResetLibrary
-from opensquirrel.ir import (
-    ANNOTATIONS_TO_TYPE_MAP,
-    IR,
-    Comment,
-    Gate,
-    Measure,
-    Qubit,
-    QubitLike,
-    Reset,
-)
+from opensquirrel.ir import ANNOTATIONS_TO_TYPE_MAP, IR, Comment, Gate, Measure, Qubit, QubitLike, Reset
 from opensquirrel.register_manager import BitRegister, QubitRegister, RegisterManager
 
 
@@ -140,12 +131,11 @@ class CircuitBuilder(GateLibrary, MeasureLibrary, ResetLibrary):
                 msg = "unknown annotation type"
                 raise TypeError(msg) from e
 
-            # fix for python39
+            # Fix for Python 3.9
             try:
                 is_incorrect_type = not isinstance(args[i], expected_type)  # type: ignore
             except TypeError:
-                # expected type is probably a Union, which works differently in
-                # python39
+                # Expected type is probably a Union, which works differently in Python 3.9
                 is_incorrect_type = not isinstance(args[i], expected_type.__args__)  # type: ignore
 
             if is_incorrect_type:

--- a/opensquirrel/decomposer/aba_decomposer.py
+++ b/opensquirrel/decomposer/aba_decomposer.py
@@ -70,37 +70,30 @@ class ABADecomposer(Decomposer, ABC):
                 p = math.pi
                 theta2 = 2 * math.acos(a_axis_value)
                 if abs(a_axis_value - 1) < ATOL or abs(a_axis_value + 1) < ATOL:
-                    # This can be anything, but setting m = p means theta3 ==
-                    # 0, which is better for gate count.
+                    # This can be anything, but setting m = p means theta3 == 0, which is better for gate count.
                     m = p
                 else:
                     m = 2 * math.acos(
-                        round(
-                            b_axis_value / math.sqrt(1 - a_axis_value**2),
-                            abs(math.floor(math.log10(ATOL))),
-                        )
+                        round(b_axis_value / math.sqrt(1 - a_axis_value**2), abs(math.floor(math.log10(ATOL)))),
                     )
 
         else:
             p = 2 * math.atan2(a_axis_value * math.sin(alpha / 2), math.cos(alpha / 2))
             acos_argument = math.cos(alpha / 2) * math.sqrt(1 + (a_axis_value * math.tan(alpha / 2)) ** 2)
 
-            # This fixes float approximations like 1.0000000000002, which acos
-            # does not like.
+            # This fixes float approximations like 1.0000000000002, which acos does not like.
             acos_argument = max(min(acos_argument, 1.0), -1.0)
 
             theta2 = 2 * math.acos(acos_argument)
             theta2 = math.copysign(theta2, alpha)
 
             if abs(math.sin(theta2 / 2)) < ATOL:
-                # This can be anything, but setting m = p means theta3 == 0,
-                # which is better for gate count.
+                # This can be anything, but setting m = p means theta3 == 0, which is better for gate count.
                 m = p
             else:
                 acos_argument = float(b_axis_value) * math.sin(alpha / 2) / math.sin(theta2 / 2)
 
-                # This fixes float approximations like 1.0000000000002, which
-                # acos does not like.
+                # This fixes float approximations like 1.0000000000002, which acos does not like.
                 acos_argument = max(min(acos_argument, 1.0), -1.0)
                 m = 2 * math.acos(acos_argument)
                 if math.pi - abs(m) > ATOL:

--- a/opensquirrel/decomposer/general_decomposer.py
+++ b/opensquirrel/decomposer/general_decomposer.py
@@ -55,11 +55,7 @@ def decompose(ir: IR, decomposer: Decomposer) -> None:
 
 
 class _GenericReplacer(Decomposer):
-    def __init__(
-        self,
-        gate_generator: Callable[..., Gate],
-        replacement_function: Callable[..., list[Gate]],
-    ) -> None:
+    def __init__(self, gate_generator: Callable[..., Gate], replacement_function: Callable[..., list[Gate]]) -> None:
         self.gate_generator = gate_generator
         self.replacement_function = replacement_function
 

--- a/opensquirrel/default_gates.py
+++ b/opensquirrel/default_gates.py
@@ -4,15 +4,7 @@ import math
 from collections.abc import Callable
 from typing import SupportsInt
 
-from opensquirrel.ir import (
-    BlochSphereRotation,
-    ControlledGate,
-    Float,
-    Gate,
-    Int,
-    QubitLike,
-    named_gate,
-)
+from opensquirrel.ir import BlochSphereRotation, ControlledGate, Float, Gate, Int, QubitLike, named_gate
 
 
 @named_gate
@@ -106,9 +98,7 @@ def CZ(control: QubitLike, target: QubitLike) -> ControlledGate:  # noqa: N802
 
 
 @named_gate
-def CR(  # noqa: N802
-    control: QubitLike, target: QubitLike, theta: Float
-) -> ControlledGate:
+def CR(control: QubitLike, target: QubitLike, theta: Float) -> ControlledGate:  # noqa: N802
     return ControlledGate(
         control,
         BlochSphereRotation(qubit=target, axis=(0, 0, 1), angle=theta.value, phase=theta.value / 2),
@@ -116,14 +106,9 @@ def CR(  # noqa: N802
 
 
 @named_gate
-def CRk(  # noqa: N802
-    control: QubitLike, target: QubitLike, k: SupportsInt
-) -> ControlledGate:
+def CRk(control: QubitLike, target: QubitLike, k: SupportsInt) -> ControlledGate:  # noqa: N802
     theta = 2 * math.pi / (2 ** Int(k).value)
-    return ControlledGate(
-        control,
-        BlochSphereRotation(qubit=target, axis=(0, 0, 1), angle=theta, phase=theta / 2),
-    )
+    return ControlledGate(control, BlochSphereRotation(qubit=target, axis=(0, 0, 1), angle=theta, phase=theta / 2))
 
 
 default_bloch_sphere_rotations_without_params: list[Callable[[QubitLike], BlochSphereRotation]]

--- a/opensquirrel/exporter/cqasmv1_exporter.py
+++ b/opensquirrel/exporter/cqasmv1_exporter.py
@@ -60,5 +60,5 @@ def export(circuit: Circuit) -> str:
 
     circuit.ir.accept(cqasmv1_creator)
 
-    # remove all trailing lines and leave only one
+    # Remove all trailing lines and leave only one
     return cqasmv1_creator.cqasmv1_string.rstrip() + "\n"

--- a/opensquirrel/exporter/quantify_scheduler_exporter.py
+++ b/opensquirrel/exporter/quantify_scheduler_exporter.py
@@ -7,15 +7,7 @@ from opensquirrel.circuit import Circuit
 from opensquirrel.common import ATOL
 from opensquirrel.default_gates import X, Z
 from opensquirrel.exceptions import ExporterError, UnsupportedGateError
-from opensquirrel.ir import (
-    BlochSphereRotation,
-    ControlledGate,
-    IRVisitor,
-    MatrixGate,
-    Measure,
-    Qubit,
-    Reset,
-)
+from opensquirrel.ir import BlochSphereRotation, ControlledGate, IRVisitor, MatrixGate, Measure, Qubit, Reset
 
 try:
     import quantify_scheduler
@@ -48,8 +40,7 @@ class _ScheduleCreator(IRVisitor):
         # Note that when adding a rotation gate to the Quantify-scheduler Schedule,
         # there exists an ambiguity with how Quantify-scheduler will store an angle of 180 degrees.
         # Depending on the system the angle may be stored as either 180 or -180 degrees.
-        # This ambiguity has no physical consequences, but may cause the
-        # exporter test to fail.
+        # This ambiguity has no physical consequences, but may cause the exporter test fail.
         g_qubit = Qubit(g.qubit)
         if abs(g.axis[2]) < ATOL:
             # Rxy rotation.
@@ -119,9 +110,7 @@ class _ScheduleCreator(IRVisitor):
         self.schedule.add(quantify_scheduler_gates.Reset(self._get_qubit_string(g.qubit)))
 
 
-def export(
-    circuit: Circuit,
-) -> tuple[quantify_scheduler.Schedule, list[tuple[Any, Any]]]:
+def export(circuit: Circuit) -> tuple[quantify_scheduler.Schedule, list[tuple[Any, Any]]]:
     if "quantify_scheduler" not in globals():
 
         class QuantifySchedulerNotInstalled:

--- a/opensquirrel/ir.py
+++ b/opensquirrel/ir.py
@@ -10,18 +10,13 @@ from typing import Any, SupportsFloat, SupportsInt, Union, cast, overload
 import numpy as np
 from numpy.typing import ArrayLike, DTypeLike, NDArray
 
-from opensquirrel.common import (
-    ATOL,
-    are_matrices_equivalent_up_to_global_phase,
-    normalize_angle,
-)
+from opensquirrel.common import ATOL, are_matrices_equivalent_up_to_global_phase, normalize_angle
 
 REPR_DECIMALS = 5
 
 
 def repr_round(
-    value: float | Axis | NDArray[np.complex64 | np.complex128],
-    decimals: int = REPR_DECIMALS,
+    value: float | Axis | NDArray[np.complex64 | np.complex128], decimals: int = REPR_DECIMALS
 ) -> float | NDArray[np.complex64 | np.complex128]:
     return np.round(value, decimals)
 
@@ -270,13 +265,7 @@ class Axis(Sequence[np.float64], Expression):
         """
         return axis / np.linalg.norm(axis)
 
-    @overload
-    def __getitem__(self, i: int, /) -> np.float64: ...
-
-    @overload
-    def __getitem__(self, s: slice, /) -> list[np.float64]: ...
-
-    def __getitem__(self, index: int | slice, /) -> np.float64 | list[np.float64]:
+    def __getitem__(self, index: int, /) -> np.float64:  # type:ignore[override]
         """Get the item at `index`."""
         return cast(np.float64, self.value[index])
 
@@ -393,8 +382,7 @@ class Gate(Statement, ABC):
         *args: Any,
         **kwargs: Any,
     ) -> None:
-        # Note: two gates are considered equal even when their
-        # generators/arguments are different.
+        # Note: two gates are considered equal even when their generators/arguments are different.
         self.generator = generator
         self.arguments = arguments
 

--- a/opensquirrel/merger/general_merger.py
+++ b/opensquirrel/merger/general_merger.py
@@ -20,8 +20,7 @@ def compose_bloch_sphere_rotations(a: BlochSphereRotation, b: BlochSphereRotatio
         raise ValueError(msg)
 
     acos_argument = cos(a.angle / 2) * cos(b.angle / 2) - sin(a.angle / 2) * sin(b.angle / 2) * np.dot(a.axis, b.axis)
-    # This fixes float approximations like 1.0000000000002 which acos doesn't
-    # like.
+    # This fixes float approximations like 1.0000000000002 which acos doesn't like.
     acos_argument = max(min(acos_argument, 1.0), -1.0)
 
     combined_angle = 2 * acos(acos_argument)
@@ -96,13 +95,13 @@ def merge_single_qubit_gates(circuit: Circuit) -> None:
     while statement_index < len(ir.statements):
         statement = ir.statements[statement_index]
 
+        # Skip, since statement is a comment
         if isinstance(statement, Comment):
-            # Skip, since statement is a comment
             statement_index += 1
             continue
 
+        # Accumulate consecutive Bloch sphere rotations
         if isinstance(statement, BlochSphereRotation):
-            # Accumulate consecutive Bloch sphere rotations
             already_accumulated = accumulators_per_qubit[statement.qubit]
 
             composed = compose_bloch_sphere_rotations(statement, already_accumulated)
@@ -111,8 +110,9 @@ def merge_single_qubit_gates(circuit: Circuit) -> None:
             del ir.statements[statement_index]
             continue
 
-        # Skip controlled-gates, measure, reset, and reset accumulator for
-        # their qubit operands
+        # For other instructions than Bloch sphere rotations,
+        # check if those instructions operate on qubits for which we keep an accumulated Bloch sphere rotation,
+        # and, in case they do, insert those corresponding accumulated Bloch sphere rotations
         for qubit_operand in statement.get_qubit_operands():  # type: ignore
             if not accumulators_per_qubit[qubit_operand].is_identity():
                 ir.statements.insert(statement_index, accumulators_per_qubit[qubit_operand])

--- a/opensquirrel/reindexer/__init__.py
+++ b/opensquirrel/reindexer/__init__.py
@@ -1,6 +1,3 @@
-from opensquirrel.reindexer.qubit_reindexer import (
-    _QubitReindexer,
-    get_reindexed_circuit,
-)
+from opensquirrel.reindexer.qubit_reindexer import _QubitReindexer, get_reindexed_circuit
 
 __all__ = ["_QubitReindexer", "get_reindexed_circuit"]

--- a/opensquirrel/reindexer/qubit_reindexer.py
+++ b/opensquirrel/reindexer/qubit_reindexer.py
@@ -3,16 +3,7 @@ from __future__ import annotations
 from collections.abc import Iterable
 from typing import TYPE_CHECKING
 
-from opensquirrel.ir import (
-    IR,
-    BlochSphereRotation,
-    ControlledGate,
-    Gate,
-    IRVisitor,
-    MatrixGate,
-    Measure,
-    Reset,
-)
+from opensquirrel.ir import IR, BlochSphereRotation, ControlledGate, Gate, IRVisitor, MatrixGate, Measure, Reset
 from opensquirrel.register_manager import BitRegister, QubitRegister, RegisterManager
 
 if TYPE_CHECKING:
@@ -41,11 +32,7 @@ class _QubitReindexer(IRVisitor):
         return Reset(qubit=qubit_to_reset)
 
     def visit_measure(self, measure: Measure) -> Measure:
-        return Measure(
-            qubit=self.qubit_indices.index(measure.qubit.index),
-            bit=measure.bit,
-            axis=measure.axis,
-        )
+        return Measure(qubit=self.qubit_indices.index(measure.qubit.index), bit=measure.bit, axis=measure.axis)
 
     def visit_bloch_sphere_rotation(self, g: BlochSphereRotation) -> BlochSphereRotation:
         return BlochSphereRotation(

--- a/opensquirrel/utils/check_passes/check_mapper.py
+++ b/opensquirrel/utils/check_passes/check_mapper.py
@@ -5,14 +5,7 @@ from __future__ import annotations
 from copy import deepcopy
 
 from opensquirrel.circuit import Circuit
-from opensquirrel.ir import (
-    IR,
-    Bit,
-    BlochSphereRotation,
-    Comment,
-    ControlledGate,
-    Measure,
-)
+from opensquirrel.ir import IR, Bit, BlochSphereRotation, Comment, ControlledGate, Measure
 from opensquirrel.mapper.general_mapper import Mapper
 from opensquirrel.register_manager import BitRegister, QubitRegister, RegisterManager
 

--- a/opensquirrel/utils/matrix_expander.py
+++ b/opensquirrel/utils/matrix_expander.py
@@ -95,9 +95,8 @@ def expand_ket(base_ket: int, reduced_ket: int, qubits: Iterable[Qubit]) -> int:
     expanded_ket = base_ket
     for i, qubit in enumerate(qubits):
         qubit = Qubit(qubit)
-        expanded_ket &= ~(1 << qubit.index)  # Erase bit.
-        # Set bit to value from reduced_ket.
-        expanded_ket |= ((reduced_ket & (1 << i)) >> i) << qubit.index
+        expanded_ket &= ~(1 << qubit.index)  # erase bit
+        expanded_ket |= ((reduced_ket & (1 << i)) >> i) << qubit.index  # set bit to value from reduced_ket
 
     return expanded_ket
 
@@ -118,10 +117,7 @@ class MatrixExpander(IRVisitor):
             ),
             np.eye(1 << rot.qubit.index),
         )
-        if result.shape != (
-            1 << self.qubit_register_size,
-            1 << self.qubit_register_size,
-        ):
+        if result.shape != (1 << self.qubit_register_size, 1 << self.qubit_register_size):
             msg = "result has incorrect shape"
             ValueError(msg)
         return result
@@ -162,10 +158,7 @@ class MatrixExpander(IRVisitor):
             )
             raise ValueError(msg)
 
-        expanded_matrix = np.zeros(
-            (1 << self.qubit_register_size, 1 << self.qubit_register_size),
-            dtype=m.dtype,
-        )
+        expanded_matrix = np.zeros((1 << self.qubit_register_size, 1 << self.qubit_register_size), dtype=m.dtype)
 
         for expanded_matrix_column in range(expanded_matrix.shape[1]):
             small_matrix_col = get_reduced_ket(expanded_matrix_column, qubit_operands)
@@ -174,10 +167,7 @@ class MatrixExpander(IRVisitor):
                 expanded_matrix_row = expand_ket(expanded_matrix_column, small_matrix_row, qubit_operands)
                 expanded_matrix[expanded_matrix_row][expanded_matrix_column] = value
 
-        if expanded_matrix.shape != (
-            1 << self.qubit_register_size,
-            1 << self.qubit_register_size,
-        ):
+        if expanded_matrix.shape != (1 << self.qubit_register_size, 1 << self.qubit_register_size):
             msg = "expended matrix has incorrect shape"
             raise ValueError(msg)
         return expanded_matrix

--- a/test/decomposer/test_mckay_decomposer.py
+++ b/test/decomposer/test_mckay_decomposer.py
@@ -63,11 +63,7 @@ def test_hadamard(decomposer: McKayDecomposer) -> None:
     gate = H(0)
     decomposed_gate = decomposer.decompose(gate)
     check_gate_replacement(gate, decomposed_gate)
-    assert decomposed_gate == [
-        Rz(0, Float(math.pi / 2)),
-        X90(0),
-        Rz(0, Float(math.pi / 2)),
-    ]
+    assert decomposed_gate == [Rz(0, Float(math.pi / 2)), X90(0), Rz(0, Float(math.pi / 2))]
 
 
 def test_arbitrary(decomposer: McKayDecomposer) -> None:

--- a/test/decomposer/test_xyx_decomposer.py
+++ b/test/decomposer/test_xyx_decomposer.py
@@ -26,14 +26,7 @@ def test_identity(decomposer: XYXDecomposer) -> None:
     [
         (CNOT(0, 1), [CNOT(0, 1)]),
         (CR(2, 3, Float(2.123)), [CR(2, 3, Float(2.123))]),
-        (
-            S(0),
-            [
-                Rx(0, Float(-math.pi / 2)),
-                Ry(0, Float(math.pi / 2)),
-                Rx(0, Float(math.pi / 2)),
-            ],
-        ),
+        (S(0), [Rx(0, Float(-math.pi / 2)), Ry(0, Float(math.pi / 2)), Rx(0, Float(math.pi / 2))]),
         (Y(0), [Ry(0, Float(math.pi))]),
         (Ry(0, Float(0.9)), [Ry(0, Float(0.9))]),
         (X(0), [Rx(0, Float(math.pi))]),
@@ -41,11 +34,7 @@ def test_identity(decomposer: XYXDecomposer) -> None:
         (H(0), [Ry(0, Float(math.pi / 2)), Rx(0, Float(math.pi))]),
         (
             BlochSphereRotation(qubit=0, angle=5.21, axis=(1, 2, 3), phase=0.324),
-            [
-                Rx(0, Float(-1.140443520488592)),
-                Ry(0, Float(-1.030183660156084)),
-                Rx(0, Float(0.8251439260060653)),
-            ],
+            [Rx(0, Float(-1.140443520488592)), Ry(0, Float(-1.030183660156084)), Rx(0, Float(0.8251439260060653))],
         ),
     ],
     ids=["CNOT", "CR", "S", "Y", "Ry", "X", "Rx", "H", "arbitrary"],

--- a/test/decomposer/test_xzx_decomposer.py
+++ b/test/decomposer/test_xzx_decomposer.py
@@ -31,21 +31,10 @@ def test_identity(decomposer: XZXDecomposer) -> None:
         (Rz(0, Float(0.9)), [Rz(0, Float(0.9))]),
         (X(0), [Rx(0, Float(math.pi))]),
         (Rx(0, Float(0.123)), [Rx(0, Float(0.123))]),
-        (
-            H(0),
-            [
-                Rx(0, Float(math.pi / 2)),
-                Rz(0, Float(math.pi / 2)),
-                Rx(0, Float(math.pi / 2)),
-            ],
-        ),
+        (H(0), [Rx(0, Float(math.pi / 2)), Rz(0, Float(math.pi / 2)), Rx(0, Float(math.pi / 2))]),
         (
             BlochSphereRotation(qubit=0, angle=5.21, axis=(1, 2, 3), phase=0.324),
-            [
-                Rx(0, Float(0.43035280630630446)),
-                Rz(0, Float(-1.030183660156084)),
-                Rx(0, Float(-0.7456524007888308)),
-            ],
+            [Rx(0, Float(0.43035280630630446)), Rz(0, Float(-1.030183660156084)), Rx(0, Float(-0.7456524007888308))],
         ),
     ],
     ids=["CNOT", "CR", "S", "Y", "Ry", "X", "Rx", "H", "arbitrary"],

--- a/test/decomposer/test_yxy_decomposer.py
+++ b/test/decomposer/test_yxy_decomposer.py
@@ -26,33 +26,15 @@ def test_identity(decomposer: YXYDecomposer) -> None:
     [
         (CNOT(0, 1), [CNOT(0, 1)]),
         (CR(2, 3, Float(2.123)), [CR(2, 3, Float(2.123))]),
-        (
-            S(0),
-            [
-                Ry(0, Float(math.pi / 2)),
-                Rx(0, Float(math.pi / 2)),
-                Ry(0, Float(-math.pi / 2)),
-            ],
-        ),
+        (S(0), [Ry(0, Float(math.pi / 2)), Rx(0, Float(math.pi / 2)), Ry(0, Float(-math.pi / 2))]),
         (Y(0), [Ry(0, Float(math.pi))]),
         (Ry(0, Float(0.9)), [Ry(0, Float(0.9))]),
         (X(0), [Rx(0, Float(math.pi))]),
         (Rx(0, Float(0.123)), [Rx(0, Float(0.123))]),
-        (
-            H(0),
-            [
-                Ry(0, Float(math.pi / 4)),
-                Rx(0, Float(math.pi)),
-                Ry(0, Float(-math.pi / 4)),
-            ],
-        ),
+        (H(0), [Ry(0, Float(math.pi / 4)), Rx(0, Float(math.pi)), Ry(0, Float(-math.pi / 4))]),
         (
             BlochSphereRotation(qubit=0, angle=5.21, axis=(1, 2, 3), phase=0.324),
-            [
-                Ry(0, Float(0.9412144817800217)),
-                Rx(0, Float(-0.893533136099803)),
-                Ry(0, Float(-1.5568770630164868)),
-            ],
+            [Ry(0, Float(0.9412144817800217)), Rx(0, Float(-0.893533136099803)), Ry(0, Float(-1.5568770630164868))],
         ),
     ],
     ids=["CNOT", "CR", "S", "Y", "Ry", "X", "Rx", "H", "arbitrary"],

--- a/test/decomposer/test_yzy_decomposer.py
+++ b/test/decomposer/test_yzy_decomposer.py
@@ -29,37 +29,15 @@ def test_identity(decomposer: YZYDecomposer) -> None:
         (S(0), [Rz(0, Float(math.pi / 2))]),
         (Y(0), [Ry(0, Float(math.pi))]),
         (Ry(0, Float(0.9)), [Ry(0, Float(0.9))]),
-        (
-            X(0),
-            [
-                Ry(0, Float(-math.pi / 2)),
-                Rz(0, Float(math.pi)),
-                Ry(0, Float(math.pi / 2)),
-            ],
-        ),
+        (X(0), [Ry(0, Float(-math.pi / 2)), Rz(0, Float(math.pi)), Ry(0, Float(math.pi / 2))]),
         (
             Rx(0, Float(0.123)),
-            [
-                Ry(0, Float(-math.pi / 2)),
-                Rz(0, Float(0.12300000000000022)),
-                Ry(0, Float(math.pi / 2)),
-            ],
+            [Ry(0, Float(-math.pi / 2)), Rz(0, Float(0.12300000000000022)), Ry(0, Float(math.pi / 2))],
         ),
-        (
-            H(0),
-            [
-                Ry(0, Float(-math.pi / 4)),
-                Rz(0, Float(math.pi)),
-                Ry(0, Float(math.pi / 4)),
-            ],
-        ),
+        (H(0), [Ry(0, Float(-math.pi / 4)), Rz(0, Float(math.pi)), Ry(0, Float(math.pi / 4))]),
         (
             BlochSphereRotation(qubit=0, angle=5.21, axis=(1, 2, 3), phase=0.324),
-            [
-                Ry(0, Float(-0.6295818450148737)),
-                Rz(0, Float(-0.893533136099803)),
-                Ry(0, Float(0.013919263778408464)),
-            ],
+            [Ry(0, Float(-0.6295818450148737)), Rz(0, Float(-0.893533136099803)), Ry(0, Float(0.013919263778408464))],
         ),
     ],
     ids=["CNOT", "CR", "S", "Y", "Ry", "X", "Rx", "H", "arbitrary"],

--- a/test/decomposer/test_zxz_decomposer.py
+++ b/test/decomposer/test_zxz_decomposer.py
@@ -28,39 +28,14 @@ def test_identity(decomposer: ZXZDecomposer) -> None:
         (CR(2, 3, Float(2.123)), [CR(2, 3, Float(2.123))]),
         (X(0), [Rx(0, Float(math.pi))]),
         (Rx(0, Float(0.9)), [Rx(0, Float(0.9))]),
-        (
-            Y(0),
-            [
-                Rz(0, Float(-math.pi / 2)),
-                Rx(0, Float(math.pi)),
-                Rz(0, Float(math.pi / 2)),
-            ],
-        ),
-        (
-            Ry(0, Float(0.9)),
-            [
-                Rz(0, Float(-math.pi / 2)),
-                Rx(0, Float(0.9000000000000004)),
-                Rz(0, Float(math.pi / 2)),
-            ],
-        ),
+        (Y(0), [Rz(0, Float(-math.pi / 2)), Rx(0, Float(math.pi)), Rz(0, Float(math.pi / 2))]),
+        (Ry(0, Float(0.9)), [Rz(0, Float(-math.pi / 2)), Rx(0, Float(0.9000000000000004)), Rz(0, Float(math.pi / 2))]),
         (Z(0), [Rz(0, Float(math.pi))]),
         (Rz(0, Float(0.123)), [Rz(0, Float(0.123))]),
-        (
-            H(0),
-            [
-                Rz(0, Float(math.pi / 2)),
-                Rx(0, Float(math.pi / 2)),
-                Rz(0, Float(math.pi / 2)),
-            ],
-        ),
+        (H(0), [Rz(0, Float(math.pi / 2)), Rx(0, Float(math.pi / 2)), Rz(0, Float(math.pi / 2))]),
         (
             BlochSphereRotation(qubit=0, angle=5.21, axis=(1, 2, 3), phase=0.324),
-            [
-                Rz(0, Float(-1.5521517485841891)),
-                Rx(0, Float(-0.6209410696845807)),
-                Rz(0, Float(0.662145687003993)),
-            ],
+            [Rz(0, Float(-1.5521517485841891)), Rx(0, Float(-0.6209410696845807)), Rz(0, Float(0.662145687003993))],
         ),
     ],
     ids=["CNOT", "CR", "X", "Rx", "Y", "Ry", "Z", "Rz", "H", "arbitrary"],

--- a/test/decomposer/test_zyz_decomposer.py
+++ b/test/decomposer/test_zyz_decomposer.py
@@ -35,11 +35,7 @@ def test_identity(decomposer: ZYZDecomposer) -> None:
         (H(0), [Rz(0, Float(math.pi)), Ry(0, Float(math.pi / 2))]),
         (
             BlochSphereRotation(qubit=0, angle=5.21, axis=(1, 2, 3), phase=0.324),
-            [
-                Rz(0, Float(0.018644578210710527)),
-                Ry(0, Float(-0.6209410696845807)),
-                Rz(0, Float(-0.9086506397909061)),
-            ],
+            [Rz(0, Float(0.018644578210710527)), Ry(0, Float(-0.6209410696845807)), Rz(0, Float(-0.9086506397909061))],
         ),
     ],
     ids=["CNOT", "CR", "X", "Rx", "Y", "Ry", "Z", "Rz", "H", "arbitrary"],

--- a/test/docs/test_tutorial.py
+++ b/test/docs/test_tutorial.py
@@ -256,7 +256,4 @@ Rz(-1.5707963) q[0]
 """
     )
 
-    assert ZYZDecomposer().decompose(H(0)) == [
-        Rz(0, Float(math.pi)),
-        Ry(0, Float(math.pi / 2)),
-    ]
+    assert ZYZDecomposer().decompose(H(0)) == [Rz(0, Float(math.pi)), Ry(0, Float(math.pi / 2))]

--- a/test/exporter/test_cqasmv1_exporter.py
+++ b/test/exporter/test_cqasmv1_exporter.py
@@ -4,15 +4,7 @@ import pytest
 from opensquirrel import Circuit, CircuitBuilder
 from opensquirrel.exceptions import UnsupportedGateError
 from opensquirrel.exporter.export_format import ExportFormat
-from opensquirrel.ir import (
-    Bit,
-    BlochSphereRotation,
-    ControlledGate,
-    Float,
-    Gate,
-    MatrixGate,
-    Qubit,
-)
+from opensquirrel.ir import Bit, BlochSphereRotation, ControlledGate, Float, Gate, MatrixGate, Qubit
 
 
 def test_cqasm_v3_to_cqasm_v1() -> None:
@@ -201,10 +193,7 @@ measure_z q[1]
     [
         BlochSphereRotation(Qubit(0), axis=(1, 1, 1), angle=1.23),
         ControlledGate(Qubit(0), BlochSphereRotation(Qubit(1), axis=(1, 1, 1), angle=1.23)),
-        MatrixGate(
-            np.array([[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 0, 1], [0, 0, 1, 0]]),
-            [Qubit(0), Qubit(1)],
-        ),
+        MatrixGate(np.array([[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 0, 1], [0, 0, 1, 0]]), [Qubit(0), Qubit(1)]),
     ],
 )
 def test_anonymous_gates(gate: Gate) -> None:

--- a/test/exporter/test_quantify_scheduler_exporter.py
+++ b/test/exporter/test_quantify_scheduler_exporter.py
@@ -59,10 +59,7 @@ class TestQuantifySchedulerExporter:
         builder.measure(2, Bit(2))
         circuit = builder.to_circuit()
 
-        with MockedQuantifyScheduler() as (
-            mock_quantify_scheduler,
-            mock_quantify_scheduler_gates,
-        ):
+        with MockedQuantifyScheduler() as (mock_quantify_scheduler, mock_quantify_scheduler_gates):
             mock_schedule = unittest.mock.MagicMock()
             mock_quantify_scheduler.Schedule.return_value = mock_schedule
 
@@ -72,17 +69,13 @@ class TestQuantifySchedulerExporter:
 
             mock_quantify_scheduler_gates.Rxy.assert_has_calls(
                 [
-                    unittest.mock.call(
-                        theta=FloatEq(math.degrees(math.pi)),
-                        phi=FloatEq(0),
-                        qubit="q[0]",
-                    ),
+                    unittest.mock.call(theta=FloatEq(math.degrees(math.pi)), phi=FloatEq(0), qubit="q[0]"),
                     unittest.mock.call(
                         theta=FloatEq(round(math.degrees(1.23), FIXED_POINT_DEG_PRECISION)),
                         phi=FloatEq(math.degrees(math.pi / 2)),
                         qubit="q[2]",
                     ),
-                ]
+                ],
             )
             mock_quantify_scheduler_gates.Reset.assert_called_once_with("q[0]")
             mock_quantify_scheduler_gates.CZ.assert_called_once_with(qC="q[0]", qT="q[1]")

--- a/test/merger/test_merger.py
+++ b/test/merger/test_merger.py
@@ -35,8 +35,7 @@ def test_single_gate() -> None:
 
     modify_circuit_and_check(circuit, general_merger.merge_single_qubit_gates, expected_circuit)
 
-    # Check that when no fusion happens, generator and arguments of gates are
-    # preserved.
+    # Check that when no fusion happens, generator and arguments of gates are preserved.
     assert isinstance(circuit.ir.statements[0], BlochSphereRotation)
     assert circuit.ir.statements[0].generator == Ry
     assert circuit.ir.statements[0].arguments == (Qubit(0), Float(1.2345))
@@ -85,12 +84,10 @@ def test_merge_different_qubits() -> None:
     modify_circuit_and_check(circuit, general_merger.merge_single_qubit_gates, expected_circuit)
 
     assert isinstance(circuit.ir.statements[0], BlochSphereRotation)
-    # When fusion happens, the resulting gate is anonymous.
-    assert circuit.ir.statements[0].is_anonymous
+    assert circuit.ir.statements[0].is_anonymous  # When fusion happens, the resulting gate is anonymous.
 
     assert isinstance(circuit.ir.statements[1], BlochSphereRotation)
-    # Otherwise it keeps the same generator and arguments.
-    assert circuit.ir.statements[1].generator == Rz
+    assert circuit.ir.statements[1].generator == Rz  # Otherwise it keeps the same generator and arguments.
     assert circuit.ir.statements[1].arguments == (Qubit(1), Float(1.2345))
 
     assert isinstance(circuit.ir.statements[2], BlochSphereRotation)

--- a/test/reindexer/test_qubit_reindexer.py
+++ b/test/reindexer/test_qubit_reindexer.py
@@ -6,14 +6,7 @@ import pytest
 
 from opensquirrel import Circuit, CircuitBuilder
 from opensquirrel.default_gates import Y90, X
-from opensquirrel.ir import (
-    Bit,
-    BlochSphereRotation,
-    ControlledGate,
-    Gate,
-    MatrixGate,
-    Measure,
-)
+from opensquirrel.ir import Bit, BlochSphereRotation, ControlledGate, Gate, MatrixGate, Measure
 from opensquirrel.reindexer.qubit_reindexer import get_reindexed_circuit
 
 

--- a/test/test_circuit_builder.py
+++ b/test/test_circuit_builder.py
@@ -55,12 +55,7 @@ class TestCircuitBuilder:
 
         assert circuit.qubit_register_size == 2
         assert circuit.qubit_register_name == "q"
-        assert circuit.ir.statements == [
-            H(0),
-            CNOT(0, 1),
-            Measure(0, Bit(0)),
-            Measure(1, Bit(1)),
-        ]
+        assert circuit.ir.statements == [H(0), CNOT(0, 1), Measure(0, Bit(0)), Measure(1, Bit(1))]
 
     def test_chain(self) -> None:
         builder = CircuitBuilder(3)

--- a/test/test_circuit_matrix_calculator.py
+++ b/test/test_circuit_matrix_calculator.py
@@ -22,14 +22,8 @@ from opensquirrel.circuit_matrix_calculator import get_circuit_matrix
             CircuitBuilder(2).H(1).X(0),
             np.sqrt(0.5) * np.array([[0, 1, 0, 1], [1, 0, 1, 0], [0, 1, 0, -1], [1, 0, -1, 0]]),
         ),
-        (
-            CircuitBuilder(2).CNOT(1, 0),
-            [[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 0, 1], [0, 0, 1, 0]],
-        ),
-        (
-            CircuitBuilder(2).CNOT(0, 1),
-            [[1, 0, 0, 0], [0, 0, 0, 1], [0, 0, 1, 0], [0, 1, 0, 0]],
-        ),
+        (CircuitBuilder(2).CNOT(1, 0), [[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 0, 1], [0, 0, 1, 0]]),
+        (CircuitBuilder(2).CNOT(0, 1), [[1, 0, 0, 0], [0, 0, 0, 1], [0, 0, 1, 0], [0, 1, 0, 0]]),
         (
             CircuitBuilder(2).H(0).CNOT(0, 1),
             np.sqrt(0.5) * np.array([[1, 1, 0, 0], [0, 0, 1, -1], [0, 0, 1, 1], [1, -1, 0, 0]]),

--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -39,8 +39,7 @@ def test_Spin2_backend() -> None:  # noqa: N802
         """,
     )
 
-    # Decompose 2-qubit gates to a decomposition where the 2-qubit
-    # interactions are captured by CNOT gates
+    # Decompose 2-qubit gates to a decomposition where the 2-qubit interactions are captured by CNOT gates
     qc.decompose(decomposer=CNOTDecomposer())
 
     # Replace CNOT gates with CZ gates
@@ -133,8 +132,7 @@ def test_hectoqubit_backend() -> None:
         """
     )
 
-    # Decompose 2-qubit gates to a decomposition where the 2-qubit
-    # interactions are captured by CNOT gates
+    # Decompose 2-qubit gates to a decomposition where the 2-qubit interactions are captured by CNOT gates
     qc.decompose(decomposer=CNOTDecomposer())
 
     # Replace CNOT gates with CZ gates

--- a/test/test_ir.py
+++ b/test/test_ir.py
@@ -52,11 +52,7 @@ class TestAxis:
         [
             (Qubit(1), TypeError, "axis requires an ArrayLike"),
             ([0, [3], [2]], TypeError, "axis requires an ArrayLike"),
-            (
-                0,
-                ValueError,
-                "axis requires an ArrayLike of length 3, but received an ArrayLike of length 1",
-            ),
+            (0, ValueError, "axis requires an ArrayLike of length 3, but received an ArrayLike of length 1"),
             (
                 [1, 2, 3, 4],
                 ValueError,
@@ -195,11 +191,7 @@ class TestMeasure:
 
     @pytest.mark.parametrize(
         "other_measure",
-        [
-            Measure(43, Bit(43), axis=(0, 0, 1)),
-            Measure(42, Bit(42), axis=(1, 0, 0)),
-            "test",
-        ],
+        [Measure(43, Bit(43), axis=(0, 0, 1)), Measure(42, Bit(42), axis=(1, 0, 0)), "test"],
         ids=["qubit", "axis", "type"],
     )
     def test_inequality(self, measure: Measure, other_measure: Measure | str) -> None:

--- a/test/test_replacer.py
+++ b/test/test_replacer.py
@@ -4,11 +4,7 @@ import pytest
 
 from opensquirrel import CircuitBuilder
 from opensquirrel.decomposer import Decomposer
-from opensquirrel.decomposer.general_decomposer import (
-    check_gate_replacement,
-    decompose,
-    replace,
-)
+from opensquirrel.decomposer.general_decomposer import check_gate_replacement, decompose, replace
 from opensquirrel.default_gates import CNOT, Y90, H, I, X
 from opensquirrel.ir import BlochSphereRotation, Gate
 
@@ -23,13 +19,7 @@ class TestCheckGateReplacement:
             (H(0), [H(0), H(0), H(0)]),
             (CNOT(0, 1), [CNOT(0, 1), I(0)]),
             # Arbitrary global phase change is not considered an issue.
-            (
-                CNOT(0, 1),
-                [
-                    CNOT(0, 1),
-                    BlochSphereRotation(0, angle=0, axis=(1, 0, 0), phase=621.6546),
-                ],
-            ),
+            (CNOT(0, 1), [CNOT(0, 1), BlochSphereRotation(0, angle=0, axis=(1, 0, 0), phase=621.6546)]),
         ],
     )
     def test_valid_replacement(self, gate: Gate, replacement_gates: list[Gate]) -> None:
@@ -38,21 +28,9 @@ class TestCheckGateReplacement:
     @pytest.mark.parametrize(
         ("gate", "replacement_gates", "error_msg"),
         [
-            (
-                H(0),
-                [H(1)],
-                "replacement for gate H does not seem to operate on the right qubits",
-            ),
-            (
-                CNOT(0, 1),
-                [CNOT(2, 1)],
-                "replacement for gate CNOT does not seem to operate on the right qubits",
-            ),
-            (
-                CNOT(0, 1),
-                [CNOT(1, 0)],
-                "replacement for gate CNOT does not preserve the quantum state",
-            ),
+            (H(0), [H(1)], "replacement for gate H does not seem to operate on the right qubits"),
+            (CNOT(0, 1), [CNOT(2, 1)], "replacement for gate CNOT does not seem to operate on the right qubits"),
+            (CNOT(0, 1), [CNOT(1, 0)], "replacement for gate CNOT does not preserve the quantum state"),
         ],
     )
     def test_wrong_qubit(self, gate: Gate, replacement_gates: list[Gate], error_msg: str) -> None:
@@ -60,20 +38,13 @@ class TestCheckGateReplacement:
             check_gate_replacement(gate, replacement_gates)
 
     def test_large_number_of_qubits(self) -> None:
-        # If we were building the whole circuit matrix, this would run out of
-        # memory.
+        # If we were building the whole circuit matrix, this would run out of memory.
         check_gate_replacement(H(9234687), [Y90(9234687), X(9234687)])
 
-        with pytest.raises(
-            ValueError,
-            match="replacement for gate H does not seem to operate on the right qubits",
-        ):
+        with pytest.raises(ValueError, match="replacement for gate H does not seem to operate on the right qubits"):
             check_gate_replacement(H(9234687), [Y90(698446519), X(9234687)])
 
-        with pytest.raises(
-            ValueError,
-            match="replacement for gate H does not preserve the quantum state",
-        ):
+        with pytest.raises(ValueError, match="replacement for gate H does not preserve the quantum state"):
             check_gate_replacement(H(9234687), [Y90(9234687), X(9234687), X(9234687)])
 
 
@@ -84,8 +55,7 @@ class TestReplacer:
         builder1.CNOT(0, 1)
         circuit = builder1.to_circuit()
 
-        # A simple decomposer function that adds identities before and after
-        # single-qubit gates.
+        # A simple decomposer function that adds identities before and after single-qubit gates.
         class TestDecomposer(Decomposer):
             def decompose(self, g: Gate) -> list[Gate]:
                 if isinstance(g, BlochSphereRotation):

--- a/test/utils/test_matrix_expander.py
+++ b/test/utils/test_matrix_expander.py
@@ -20,10 +20,7 @@ def test_bloch_sphere_rotation() -> None:
 
 
 def test_controlled_gate() -> None:
-    gate = ControlledGate(
-        2,
-        BlochSphereRotation(qubit=0, axis=(1, 0, 0), angle=math.pi, phase=math.pi / 2),
-    )
+    gate = ControlledGate(2, BlochSphereRotation(qubit=0, axis=(1, 0, 0), angle=math.pi, phase=math.pi / 2))
     np.testing.assert_almost_equal(
         matrix_expander.get_matrix(gate, 3),
         [


### PR DESCRIPTION
Reverted unwanted changes from [CQT-115] PEP8 naming.
This PR still keeps PEP8 naming enabled in pyproject.tml.