### PR TITLE
Rewrite `get_decomposition_angles` (2)

### DIFF
--- a/opensquirrel/passes/decomposer/cnot_decomposer.py
+++ b/opensquirrel/passes/decomposer/cnot_decomposer.py
@@ -40,8 +40,8 @@ class CNOTDecomposer(Decomposer):
         # Try special case first, see https://arxiv.org/pdf/quant-ph/9503016.pdf lemma 5.5
         controlled_rotation_times_x = general_merger.compose_bloch_sphere_rotations(X(target_qubit), g.target_gate)
         theta0_with_x, theta1_with_x, theta2_with_x = ZYZDecomposer().get_decomposition_angles(
-            controlled_rotation_times_x.angle,
             controlled_rotation_times_x.axis,
+            controlled_rotation_times_x.angle,
         )
         if abs((theta0_with_x - theta2_with_x) % (2 * math.pi)) < ATOL:
             # The decomposition can use a single CNOT according to the lemma.
@@ -57,7 +57,7 @@ class CNOTDecomposer(Decomposer):
                 ],
             )
 
-        theta0, theta1, theta2 = ZYZDecomposer().get_decomposition_angles(g.target_gate.angle, g.target_gate.axis)
+        theta0, theta1, theta2 = ZYZDecomposer().get_decomposition_angles(g.target_gate.axis, g.target_gate.angle)
 
         A = [Ry(target_qubit, theta1 / 2), Rz(target_qubit, theta2)]  # noqa: N806
         B = [Rz(target_qubit, -(theta0 + theta2) / 2), Ry(target_qubit, -theta1 / 2)]  # noqa: N806


### PR DESCRIPTION
Move `_set_axes_values` out of `get_decomposition_angles`.
Rename `_set_axes_values` to `_set_a_b_c_axes_value`s.
Convert `_calculate.*` functions back to code with a comment.
Change `get_decomposition_angles` parameter order.
Update doc for `get_decomposition_angles` and `_set_a_b_c_axes_values`.