### PR TITLE
[CQT-312] Align compiler config

### DIFF
--- a/opensquirrel/passes/router/__init__.py
+++ b/opensquirrel/passes/router/__init__.py
@@ -1,0 +1,7 @@
+from opensquirrel.passes.router.general_router import Router
+from opensquirrel.passes.router.routing_checker import RoutingChecker
+
+__all__ = [
+    "Router",
+    "RoutingChecker",
+]

--- a/opensquirrel/passes/router/routing_checker.py
+++ b/opensquirrel/passes/router/routing_checker.py
@@ -5,8 +5,8 @@ from opensquirrel.passes.router.general_router import Router
 
 
 class RoutingChecker(Router):
-    def __init__(self, backend_connectivity_diagram: dict[int, list[int]]) -> None:
-        self.backend_connectivity_diagram = backend_connectivity_diagram
+    def __init__(self, connectivity: dict[str, list[int]]) -> None:
+        self.connectivity = connectivity
 
     def route(self, ir: IR) -> None:
         non_executable_interactions = []
@@ -17,7 +17,7 @@ class RoutingChecker(Router):
                 qubit_args = [arg for arg in args if isinstance(arg, Qubit)]
                 qubit_index_pairs = [(q0.index, q1.index) for q0, q1 in zip(qubit_args[:-1], qubit_args[1:])]
                 for i, j in qubit_index_pairs:
-                    if j not in self.backend_connectivity_diagram.get(i, []):
+                    if j not in self.connectivity.get(str(i), []):
                         non_executable_interactions.append((i, j))
 
         if non_executable_interactions:

--- a/test/router/test_routing_checker.py
+++ b/test/router/test_routing_checker.py
@@ -9,8 +9,8 @@ from opensquirrel.passes.router.routing_checker import RoutingChecker
 
 @pytest.fixture(name="router")
 def router_fixture() -> RoutingChecker:
-    backend_connectivity_diagram = {0: [1, 2], 1: [0, 2, 3], 2: [0, 1, 4], 3: [1, 4], 4: [2, 3]}
-    return RoutingChecker(backend_connectivity_diagram)
+    connectivity = {"0": [1, 2], "1": [0, 2, 3], "2": [0, 1, 4], "3": [1, 4], "4": [2, 3]}
+    return RoutingChecker(connectivity)
 
 
 @pytest.fixture

--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -15,11 +15,11 @@ from opensquirrel.passes.decomposer import (
     XYXDecomposer,
 )
 from opensquirrel.passes.exporter import ExportFormat
-from opensquirrel.passes.merger.single_qubit_gates_merger import SingleQubitGatesMerger
-from opensquirrel.passes.router.routing_checker import RoutingChecker
+from opensquirrel.passes.merger import SingleQubitGatesMerger
+from opensquirrel.passes.router import RoutingChecker
 
 
-def test_spin_backend() -> None:
+def test_spin2plus_backend() -> None:
     qc = Circuit.from_string(
         """
         version 3.0
@@ -30,29 +30,30 @@ def test_spin_backend() -> None:
         /* This is a multi-
         line comment block */
 
-        qubit[4] q
+        qubit[2] q
         bit[4] b
 
-        H q[0:2]
+        H q[0:1]
         Rx(1.5789) q[0]
         Ry(-0.2) q[0]
         Rz(1.5707963) q[0]
         CNOT q[1], q[0]
-        CR(2.123) q[2], q[3]
-        CRk(2) q[0], q[2]
+        CR(2.123) q[0], q[1]
+        CRk(2) q[0], q[1]
         SWAP q[0], q[1]
-        b = measure q
+        b[1,3] = measure q
         """,
     )
 
     # Check whether the above algorithm can be mapped to a dummy chip topology
-    connectivity = {0: [1, 2], 1: [0], 2: [0, 3], 3: [2]}
+    connectivity = {"0": [1], "1": [0]}
 
-    qc.route(router=RoutingChecker(connectivity))
-    # Decompose 2-qubit gates to a decomposition where the 2-qubit interactions are captured by CNOT gates
-    qc.decompose(decomposer=CNOTDecomposer())
+    qc.route(router=RoutingChecker(connectivity=connectivity))
 
     qc.decompose(decomposer=SWAP2CNOTDecomposer())
+
+    # Decompose 2-qubit gates to a decomposition where the 2-qubit interactions are captured by CNOT gates
+    qc.decompose(decomposer=CNOTDecomposer())
 
     # Replace CNOT gates with CZ gates
     qc.decompose(decomposer=CNOT2CZDecomposer())
@@ -67,7 +68,7 @@ def test_spin_backend() -> None:
         str(qc)
         == """version 3.0
 
-qubit[4] q
+qubit[2] q
 bit[4] b
 
 Rz(1.5707963) q[1]
@@ -77,36 +78,33 @@ Rz(1.5789) q[0]
 X90 q[0]
 Rz(-2.9415926) q[0]
 CZ q[1], q[0]
-Rz(1.5707963) q[2]
-X90 q[2]
-Rz(1.5707963) q[2]
-Rz(2.6322964) q[3]
-X90 q[3]
-Rz(-1.5707963) q[3]
-CZ q[2], q[3]
-Rz(-1.5707963) q[3]
-X90 q[3]
-Rz(2.0800926) q[3]
-X90 q[3]
-Rz(-1.5707963) q[3]
-CZ q[2], q[3]
 Rz(-1.5707963) q[0]
 X90 q[0]
 Rz(1.5707963) q[0]
-Rz(3.4176945) q[2]
-X90 q[2]
-Rz(-1.5707963) q[2]
-CZ q[0], q[2]
-Rz(-1.5707963) q[2]
-X90 q[2]
-Rz(2.3561946) q[2]
-X90 q[2]
-Rz(-1.5707963) q[2]
-CZ q[0], q[2]
-Rz(0.78539816) q[0]
-Rz(1.5707963) q[1]
+Rz(2.6322964) q[1]
 X90 q[1]
 Rz(-1.5707963) q[1]
+CZ q[0], q[1]
+Rz(-1.5707963) q[1]
+X90 q[1]
+Rz(2.0800926) q[1]
+X90 q[1]
+Rz(-1.5707963) q[1]
+CZ q[0], q[1]
+Rz(1.0615) q[0]
+Rz(1.5707963) q[1]
+X90 q[1]
+Rz(2.3561946) q[1]
+X90 q[1]
+Rz(1.5707963) q[1]
+CZ q[0], q[1]
+Rz(-1.5707963) q[1]
+X90 q[1]
+Rz(2.3561946) q[1]
+X90 q[1]
+Rz(-1.5707963) q[1]
+CZ q[0], q[1]
+Rz(0.78539816) q[0]
 CZ q[0], q[1]
 Rz(-1.5707963) q[1]
 X90 q[1]
@@ -122,19 +120,11 @@ Rz(1.5707963) q[1]
 X90 q[1]
 Rz(-1.5707963) q[1]
 CZ q[0], q[1]
-b[0] = measure q[0]
+b[1] = measure q[0]
 Rz(-1.5707963) q[1]
 X90 q[1]
 Rz(1.5707963) q[1]
-b[1] = measure q[1]
-Rz(-1.5707963) q[2]
-X90 q[2]
-Rz(1.5707963) q[2]
-b[2] = measure q[2]
-Rz(-1.5707963) q[3]
-X90 q[3]
-Rz(1.5707963) q[3]
-b[3] = measure q[3]
+b[3] = measure q[1]
 """
     )
 


### PR DESCRIPTION
- change start node type from int to string of connectivity
- change input argument name of RoutingChecker to connectivity
- add `__init__.py` to routing module
- update spin2plus integration test to match compiler config 