### PR TITLE
Change circuit depth logic

### DIFF
--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -4,14 +4,12 @@ from __future__ import annotations
 import importlib.util
 
 import pytest
-from quantify_scheduler.compilation import _determine_absolute_timing_schedule
 
 from opensquirrel.circuit import Circuit
 from opensquirrel.ir import Measure
 from opensquirrel.passes.decomposer import (
     CNOT2CZDecomposer,
     CNOTDecomposer,
-    CZDecomposer,
     McKayDecomposer,
     SWAP2CNOTDecomposer,
     XYXDecomposer,


### PR DESCRIPTION
NOTE: Since many changes were done without proper commit hygiene, I have added commit-like comments to the changes made in the source code

# Changes made to circuit-depth logic:
1. In `OperationRecord.set_timing_constraints`, `OperationRecord._schedulable_counters` is now incremented using `qubit_index` instead of `ref_qubit_index`
2. In `OperationRecord._process_barriers`, the values of `OperationRecord._schedulable_counters` are all set to the same value as `OperationRecord._schedulable_counters[ref_qubit_index]`. Where `ref_qubit_index` is determined within `OperationRecord._process_barriers`.
3. Two-qubit gate circuit-depth logic is now handled by a new method `OperationRecord.equalize_schedulable_counts_after_two_qubit_gate`. Thich sets the `OperationRecord._schedulable_counters` of the two qubit indices to the maximum of the two.
4. Adds the methods `_Scheduler.visit_cz` and `_Scheduler.visit_cnot` to make `_Scheduler` aware of added two-qubit gate logic in `OperationRecord`.

# Changes made to timing constraints:
1. Added default value for `rel_time` as this was needed by quantify-scheduler

# Changes made to handling of gates:
1. Hotfix to specifically enable the use of Hadamard gates