### PR TITLE
[CQT-381] The Routing validator should skip asm declarations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 * **Fixed** for any bug fixes.
 * **Removed** for now removed features.
 
+## [ 0.4.1 ] - [ xxxx-yy-zz ]
+
+### Fixed
+
+- `RoutingValidator` ignores assembly declarations
 
 ## [ 0.4.0 ] - [ 2025-04-28 ]
 

--- a/opensquirrel/passes/validator/routing_validator.py
+++ b/opensquirrel/passes/validator/routing_validator.py
@@ -1,6 +1,6 @@
 from typing import Any, cast
 
-from opensquirrel.ir import IR, Instruction, Qubit
+from opensquirrel.ir import IR, AsmDeclaration, Instruction, Qubit
 from opensquirrel.passes.validator import Validator
 
 
@@ -21,6 +21,8 @@ class RoutingValidator(Validator):
         """
         non_executable_interactions = []
         for statement in ir.statements:
+            if isinstance(statement, AsmDeclaration):
+                continue
             instruction: Instruction = cast("Instruction", statement)
             args = instruction.arguments
             if args and len(args) > 1 and all(isinstance(arg, Qubit) for arg in args):

--- a/test/validator/test_routing_validator.py
+++ b/test/validator/test_routing_validator.py
@@ -4,6 +4,7 @@ import pytest
 
 from opensquirrel import CircuitBuilder
 from opensquirrel.circuit import Circuit
+from opensquirrel.ir import AsmDeclaration
 from opensquirrel.passes.validator import RoutingValidator
 
 
@@ -52,3 +53,14 @@ def test_routing_checker_impossible_1to1_mapping(validator: RoutingValidator, ci
         ValueError, match=r"the following qubit interactions in the circuit prevent a 1-to-1 mapping:.*"
     ):
         validator.validate(circuit2.ir)
+
+
+def test_ignore_asm(validator: RoutingValidator) -> None:
+    builder = CircuitBuilder(2)
+    builder.H(0)
+    builder.asm("backend_name", r"backend_code")
+    builder.CNOT(0, 1)
+    qc = builder.to_circuit()
+    validator.validate(qc.ir)
+
+    assert len([statement for statement in qc.ir.statements if isinstance(statement, AsmDeclaration)]) == 1


### PR DESCRIPTION
Fix ignore asm declaration in RoutingValidator.
Add test to ignore asm declarations.
Add entry to Changelog.