### PR TITLE
[CQT-364] Revise and test known gate identification after merging

### DIFF
--- a/opensquirrel/ir.py
+++ b/opensquirrel/ir.py
@@ -502,13 +502,12 @@ class BlochSphereRotation(Gate):
         if self.qubit != other.qubit:
             return False
 
-        if abs(self.phase - other.phase) > ATOL:
-            return False
-
         if np.allclose(self.axis, other.axis, atol=ATOL):
-            return abs(self.angle - other.angle) < ATOL
+            return abs(self.angle - other.angle) < ATOL and abs(self.phase - other.phase) < ATOL
+
         if np.allclose(self.axis, -other.axis.value, atol=ATOL):
-            return abs(self.angle + other.angle) < ATOL
+            return abs(self.angle + other.angle) < ATOL and abs(self.phase + other.phase) < ATOL
+
         return False
 
     @property
@@ -542,17 +541,14 @@ class BlochSphereRotation(Gate):
             default_bsr_without_params_set,
         )
 
-        bsr_set_without_rn = {**default_bsr_without_params_set, **default_bsr_with_angle_param_set}
-        for gate_name in bsr_set_without_rn:
+        default_bsr_set_without_rn = {**default_bsr_without_params_set, **default_bsr_with_angle_param_set}
+        for gate_name in default_bsr_set_without_rn:
             arguments: tuple[Any, ...] = (bsr.qubit,)
             if gate_name in default_bsr_with_angle_param_set:
                 arguments += (Float(bsr.angle),)
-            gate = bsr_set_without_rn[gate_name](*arguments)
-            if (
-                np.allclose(gate.axis, bsr.axis, atol=ATOL)
-                and np.allclose(gate.angle, bsr.angle, atol=ATOL)
-                and np.allclose(gate.phase, bsr.phase, atol=ATOL)
-            ):
+            gate = default_bsr_set_without_rn[gate_name](*arguments)
+            gate_bsr = BlochSphereRotation(gate.qubit, axis=gate.axis, angle=gate.angle, phase=gate.phase)
+            if bsr == gate_bsr:
                 return gate
         nx, ny, nz = (Float(component) for component in bsr.axis)
         return Rn(bsr.qubit, nx, ny, nz, Float(bsr.angle), Float(bsr.phase))
@@ -579,7 +575,7 @@ class BsrNoParams(BlochSphereRotation):
 
 class I(BsrNoParams):  # noqa: E742
     def __init__(self, qubit: QubitLike) -> None:
-        BsrNoParams.__init__(self, qubit=qubit, axis=(1, 0, 0), angle=0, phase=0, name="I")
+        BsrNoParams.__init__(self, qubit=qubit, axis=(0, 0, 1), angle=0, phase=0, name="I")
 
 
 class H(BsrNoParams):
@@ -594,12 +590,12 @@ class X(BsrNoParams):
 
 class X90(BsrNoParams):
     def __init__(self, qubit: QubitLike) -> None:
-        BsrNoParams.__init__(self, qubit=qubit, axis=(1, 0, 0), angle=math.pi / 2, phase=0, name="X90")
+        BsrNoParams.__init__(self, qubit=qubit, axis=(1, 0, 0), angle=math.pi / 2, phase=math.pi / 4, name="X90")
 
 
 class MinusX90(BsrNoParams):
     def __init__(self, qubit: QubitLike) -> None:
-        BsrNoParams.__init__(self, qubit=qubit, axis=(1, 0, 0), angle=-math.pi / 2, phase=-0, name="mX90")
+        BsrNoParams.__init__(self, qubit=qubit, axis=(1, 0, 0), angle=-math.pi / 2, phase=-math.pi / 4, name="mX90")
 
 
 class Y(BsrNoParams):
@@ -609,12 +605,12 @@ class Y(BsrNoParams):
 
 class Y90(BsrNoParams):
     def __init__(self, qubit: QubitLike) -> None:
-        BsrNoParams.__init__(self, qubit=qubit, axis=(0, 1, 0), angle=math.pi / 2, phase=0, name="Y90")
+        BsrNoParams.__init__(self, qubit=qubit, axis=(0, 1, 0), angle=math.pi / 2, phase=math.pi / 4, name="Y90")
 
 
 class MinusY90(BsrNoParams):
     def __init__(self, qubit: QubitLike) -> None:
-        BsrNoParams.__init__(self, qubit=qubit, axis=(0, 1, 0), angle=-math.pi / 2, phase=0, name="mY90")
+        BsrNoParams.__init__(self, qubit=qubit, axis=(0, 1, 0), angle=-math.pi / 2, phase=-math.pi / 4, name="mY90")
 
 
 class Z(BsrNoParams):
@@ -624,22 +620,22 @@ class Z(BsrNoParams):
 
 class S(BsrNoParams):
     def __init__(self, qubit: QubitLike) -> None:
-        BsrNoParams.__init__(self, qubit=qubit, axis=(0, 0, 1), angle=math.pi / 2, phase=0, name="S")
+        BsrNoParams.__init__(self, qubit=qubit, axis=(0, 0, 1), angle=math.pi / 2, phase=math.pi / 4, name="S")
 
 
 class SDagger(BsrNoParams):
     def __init__(self, qubit: QubitLike) -> None:
-        BsrNoParams.__init__(self, qubit=qubit, axis=(0, 0, 1), angle=-math.pi / 2, phase=0, name="Sdag")
+        BsrNoParams.__init__(self, qubit=qubit, axis=(0, 0, 1), angle=-math.pi / 2, phase=-math.pi / 4, name="Sdag")
 
 
 class T(BsrNoParams):
     def __init__(self, qubit: QubitLike) -> None:
-        BsrNoParams.__init__(self, qubit=qubit, axis=(0, 0, 1), angle=math.pi / 4, phase=0, name="T")
+        BsrNoParams.__init__(self, qubit=qubit, axis=(0, 0, 1), angle=math.pi / 4, phase=math.pi / 8, name="T")
 
 
 class TDagger(BsrNoParams):
     def __init__(self, qubit: QubitLike) -> None:
-        BsrNoParams.__init__(self, qubit=qubit, axis=(0, 0, 1), angle=-math.pi / 4, phase=0, name="Tdag")
+        BsrNoParams.__init__(self, qubit=qubit, axis=(0, 0, 1), angle=-math.pi / 4, phase=-math.pi / 8, name="Tdag")
 
 
 class BsrFullParams(BlochSphereRotation):

--- a/test/decomposer/test_zyz_decomposer.py
+++ b/test/decomposer/test_zyz_decomposer.py
@@ -26,8 +26,8 @@ def test_identity(decomposer: ZYZDecomposer) -> None:
     [
         (CNOT(0, 1), [CNOT(0, 1)]),
         (CR(2, 3, 2.123), [CR(2, 3, 2.123)]),
-        (X(0), [S(0), Ry(0, math.pi), SDagger(0)]),
-        (Rx(0, 0.9), [S(0), Ry(0, 0.9), SDagger(0)]),
+        (X(0), [Rz(0, math.pi / 2), Ry(0, math.pi), Rz(0, -math.pi / 2)]),
+        (Rx(0, 0.9), [Rz(0, math.pi / 2), Ry(0, 0.9), Rz(0, -math.pi / 2)]),
         (Y(0), [Ry(0, math.pi)]),
         (Ry(0, 0.9), [Ry(0, 0.9)]),
         (Z(0), [Rz(0, math.pi)]),

--- a/test/merger/test_single_qubit_gates_merger.py
+++ b/test/merger/test_single_qubit_gates_merger.py
@@ -91,7 +91,7 @@ def test_merge_and_flush(merger: SingleQubitGatesMerger) -> None:
 
 def test_merge_y90_x_to_h(merger: SingleQubitGatesMerger) -> None:
     builder = CircuitBuilder(1)
-    builder.Y90(0)
+    builder.Ry(0, math.pi / 2)
     builder.X(0)
     qc = builder.to_circuit()
 

--- a/test/test_asm_declaration.py
+++ b/test/test_asm_declaration.py
@@ -147,10 +147,10 @@ CNOT q[0], q[1]
 def test_no_merging_across_asm() -> None:
     builder = CircuitBuilder(2)
     builder.H(0)
-    builder.Ry(1, math.pi / 2)
+    builder.Y90(1)
     builder.asm("TestBackend", """ a ' " {} () [] b """)
     builder.H(0)
-    builder.Rx(1, math.pi / 2)
+    builder.X90(1)
     qc = builder.to_circuit()
     qc.merge(merger=SingleQubitGatesMerger())
     assert (

--- a/test/test_ir.py
+++ b/test/test_ir.py
@@ -10,6 +10,7 @@ from numpy.typing import NDArray
 
 from opensquirrel.common import ATOL
 from opensquirrel.ir import (
+    X90,
     Axis,
     AxisLike,
     Bit,
@@ -17,11 +18,19 @@ from opensquirrel.ir import (
     ControlledGate,
     Expression,
     Float,
+    H,
     I,
     Int,
     MatrixGate,
     Measure,
+    MinusX90,
     Qubit,
+    Rn,
+    Rx,
+    Ry,
+    Rz,
+    TDagger,
+    X,
 )
 
 
@@ -303,6 +312,28 @@ class TestBlochSphereRotation:
     def test_is_identity(self, gate: BlochSphereRotation) -> None:
         assert I(42).is_identity()
         assert not gate.is_identity()
+
+    @pytest.mark.parametrize(
+        ("bsr", "default_gate"),
+        [
+            (BlochSphereRotation(qubit=0, axis=(1, 0, 1), angle=math.pi, phase=math.pi / 2), H(0)),
+            (BlochSphereRotation(qubit=0, axis=(1, 0, 0), angle=math.pi, phase=math.pi / 2), X(0)),
+            (BlochSphereRotation(qubit=0, axis=(1, 0, 0), angle=math.pi / 2, phase=math.pi / 4), X90(0)),
+            (BlochSphereRotation(qubit=0, axis=(-1, 0, 0), angle=-math.pi / 2, phase=-math.pi / 4), X90(0)),
+            (BlochSphereRotation(qubit=0, axis=(1, 0, 0), angle=-math.pi / 2, phase=-math.pi / 4), MinusX90(0)),
+            (BlochSphereRotation(qubit=0, axis=(-1, 0, 0), angle=math.pi / 2, phase=math.pi / 4), MinusX90(0)),
+            (BlochSphereRotation(qubit=0, axis=(0, 0, 1), angle=-math.pi / 4, phase=-math.pi / 8), TDagger(0)),
+            (BlochSphereRotation(qubit=0, axis=(1, 0, 0), angle=math.pi / 4, phase=0), Rx(0, math.pi / 4)),
+            (BlochSphereRotation(qubit=0, axis=(0, 1, 0), angle=math.pi / 3, phase=0), Ry(0, math.pi / 3)),
+            (BlochSphereRotation(qubit=0, axis=(0, 0, 1), angle=3 * math.pi / 4, phase=0), Rz(0, 3 * math.pi / 4)),
+            (BlochSphereRotation(qubit=0, axis=(1, 0, 1), angle=math.pi, phase=0), Rn(0, 1, 0, 1, math.pi, 0)),
+        ],
+        ids=["H", "X", "X90-1", "X90-2", "mX90-1", "mX90-2", "Tdag", "Rx", "Ry", "Rz", "Rn"],
+    )
+    def test_default_gate_matching(self, bsr: BlochSphereRotation, default_gate: BlochSphereRotation) -> None:
+        matched_bsr = BlochSphereRotation.try_match_replace_with_default(bsr)
+        assert matched_bsr == default_gate
+        assert matched_bsr.name == default_gate.name
 
 
 class TestMatrixGate:


### PR DESCRIPTION
- Updated gate identification to check for BSR equality.
- Added (absolute) phase check to BSR equality.
- Added correct phases to standard gates.
- Updated tests in accordance with new equality check (now with phase included)