### PR TITLE
Fix Axis.__array__ signature; Improve performance of Axis.__eq__

### DIFF
--- a/opensquirrel/default_instructions.py
+++ b/opensquirrel/default_instructions.py
@@ -125,6 +125,8 @@ default_instruction_set = {
     **default_non_unitary_set,
 }
 
+default_bsr_set_without_rn : Mapping[str, type[BsrNoParams]]
+default_bsr_set_without_rn = {**default_bsr_without_params_set, **default_bsr_with_angle_param_set}
 
 def is_anonymous_gate(name: str) -> bool:
     return name not in default_gate_set

--- a/opensquirrel/ir/expression.py
+++ b/opensquirrel/ir/expression.py
@@ -268,7 +268,7 @@ class Axis(Sequence[np.float64], Expression):
         """String representation of the ``Axis``."""
         return f"Axis{self.value}"
 
-    def __array__(self, dtype: DTypeLike = None, *, copy: bool = True) -> NDArray[Any]:
+    def __array__(self, dtype: DTypeLike = None, *, copy: bool | None = None) -> NDArray[Any]:
         """Convert the ``Axis`` data to an array."""
         return np.array(self.value, dtype=dtype, copy=copy)
 

--- a/opensquirrel/ir/semantics/bsr.py
+++ b/opensquirrel/ir/semantics/bsr.py
@@ -40,11 +40,10 @@ class BlochSphereRotation(Gate):
         """
         from opensquirrel.default_instructions import (
             default_bsr_with_angle_param_set,
-            default_bsr_without_params_set,
+            default_bsr_without_params_set, default_bsr_set_without_rn
         )
         from opensquirrel.ir.default_gates import Rn
 
-        default_bsr_set_without_rn = {**default_bsr_without_params_set, **default_bsr_with_angle_param_set}
         for gate_name in default_bsr_set_without_rn:
             arguments: tuple[Any, ...] = (bsr.qubit,)
             if gate_name in default_bsr_with_angle_param_set:
@@ -86,10 +85,10 @@ class BlochSphereRotation(Gate):
         if self.qubit != other.qubit:
             return False
 
-        if np.allclose(self.axis, other.axis, atol=ATOL):
+        if np.allclose(self.axis.value, other.axis.value, atol=ATOL):
             return abs(self.angle - other.angle) < ATOL and abs(self.phase - other.phase) < ATOL
 
-        if np.allclose(self.axis, -other.axis.value, atol=ATOL):
+        if np.allclose(self.axis.value, -other.axis.value, atol=ATOL):
             return abs(self.angle + other.angle) < ATOL and abs(self.phase + other.phase) < ATOL
 
         return False


### PR DESCRIPTION
* The signature of `__array__` should have `copy=None`. See https://numpy.org/doc/stable/user/basics.interoperability.html#the-array-method. 
* Construct `default_bsr_set_without_rn` only once.