### PR TITLE
[CQT-410] Move pytest options from pyproject.toml to tox.ini to enable debugging

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,7 +78,7 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [tool.pytest.ini_options]
-addopts = "-v --cov --cov-report term-missing:skip-covered --cov-report xml"
+addopts = "-v"
 
 [tool.coverage.run]
 branch = true

--- a/tox.ini
+++ b/tox.ini
@@ -33,4 +33,4 @@ commands =
 [testenv:test]
 description = run unit tests
 commands =
-    uv run pytest . -vv
+    uv run pytest . -vv --cov --cov-report=term-missing --cov-report=xml


### PR DESCRIPTION
- Move pytest config from pyproject.toml to tox.ini.