### PR TITLE
Fix Circuitbuilder autocompletion

### DIFF
--- a/opensquirrel/circuit_builder.py
+++ b/opensquirrel/circuit_builder.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from collections.abc import Callable
 from copy import deepcopy
 from functools import partial
 from typing import Any

--- a/opensquirrel/circuit_builder.py
+++ b/opensquirrel/circuit_builder.py
@@ -46,10 +46,11 @@ class CircuitBuilder:
     def __dir__(self) -> list[str]:
         return super().__dir__() + list(_builder_dynamic_attributes)  # type: ignore
 
-    def __getattr__(self, attr: Any) -> Any:
+    def __getattr__(self, attr: str) -> Any:
         if attr in _builder_dynamic_attributes:
             return partial(self._add_statement, attr)
-        return super.__getattr__(attr)
+        # Default behaviour
+        return self.__getattribute__(attr)
 
     def _check_qubit_out_of_bounds_access(self, qubit: QubitLike) -> None:
         """Throw error if qubit index is outside the qubit register range.

--- a/opensquirrel/circuit_builder.py
+++ b/opensquirrel/circuit_builder.py
@@ -12,6 +12,7 @@ from opensquirrel.default_instructions import default_instruction_set
 from opensquirrel.ir import IR, AsmDeclaration, Bit, BitLike, Instruction, Qubit, QubitLike
 from opensquirrel.register_manager import BitRegister, QubitRegister, RegisterManager
 
+_builder_dynamic_attributes = tuple(default_instruction_set + ['asm'])
 
 class CircuitBuilder:
     """
@@ -42,8 +43,13 @@ class CircuitBuilder:
         self.register_manager = RegisterManager(QubitRegister(qubit_register_size), BitRegister(bit_register_size))
         self.ir = IR()
 
+    def __dir__(self):
+        return super().__dir__() + list(_builder_dynamic_attributes)
+
     def __getattr__(self, attr: Any) -> Callable[..., Self]:
-        return partial(self._add_statement, attr)
+        if attr in _builder_dynamic_attributes:
+            return partial(self._add_statement, attr)
+        return super.__getattr__(attr)
 
     def _check_qubit_out_of_bounds_access(self, qubit: QubitLike) -> None:
         """Throw error if qubit index is outside the qubit register range.

--- a/opensquirrel/circuit_builder.py
+++ b/opensquirrel/circuit_builder.py
@@ -12,7 +12,8 @@ from opensquirrel.default_instructions import default_instruction_set
 from opensquirrel.ir import IR, AsmDeclaration, Bit, BitLike, Instruction, Qubit, QubitLike
 from opensquirrel.register_manager import BitRegister, QubitRegister, RegisterManager
 
-_builder_dynamic_attributes = tuple(default_instruction_set + ['asm'])
+_builder_dynamic_attributes = (*default_instruction_set, "asm")
+
 
 class CircuitBuilder:
     """
@@ -43,7 +44,7 @@ class CircuitBuilder:
         self.register_manager = RegisterManager(QubitRegister(qubit_register_size), BitRegister(bit_register_size))
         self.ir = IR()
 
-    def __dir__(self):
+    def __dir__(self) -> list[str]:
         return super().__dir__() + list(_builder_dynamic_attributes)
 
     def __getattr__(self, attr: Any) -> Callable[..., Self]:

--- a/opensquirrel/circuit_builder.py
+++ b/opensquirrel/circuit_builder.py
@@ -45,9 +45,9 @@ class CircuitBuilder:
         self.ir = IR()
 
     def __dir__(self) -> list[str]:
-        return super().__dir__() + list(_builder_dynamic_attributes)
+        return super().__dir__() + list(_builder_dynamic_attributes)  # type: ignore
 
-    def __getattr__(self, attr: Any) -> Callable[..., Self]:
+    def __getattr__(self, attr: Any) -> Any:
         if attr in _builder_dynamic_attributes:
             return partial(self._add_statement, attr)
         return super.__getattr__(attr)

--- a/opensquirrel/passes/router/general_router.py
+++ b/opensquirrel/passes/router/general_router.py
@@ -7,7 +7,6 @@ from opensquirrel.ir import IR
 class Router(ABC):
     def __init__(self, **kwargs: Any) -> None:
         """ Generic router class """
-        ...
 
     @abstractmethod
     def route(self, ir: IR) -> IR:

--- a/opensquirrel/passes/router/general_router.py
+++ b/opensquirrel/passes/router/general_router.py
@@ -5,7 +5,9 @@ from opensquirrel.ir import IR
 
 
 class Router(ABC):
-    def __init__(self, **kwargs: Any) -> None: ...
+    def __init__(self, **kwargs: Any) -> None:
+        """ Router class to map a quantum algorithm on the specific topology """
+        ...
 
     @abstractmethod
     def route(self, ir: IR) -> IR:

--- a/opensquirrel/passes/router/general_router.py
+++ b/opensquirrel/passes/router/general_router.py
@@ -6,7 +6,7 @@ from opensquirrel.ir import IR
 
 class Router(ABC):
     def __init__(self, **kwargs: Any) -> None:
-        """ Generic router class """
+        """Generic router class"""
 
     @abstractmethod
     def route(self, ir: IR) -> IR:

--- a/opensquirrel/passes/router/general_router.py
+++ b/opensquirrel/passes/router/general_router.py
@@ -6,7 +6,7 @@ from opensquirrel.ir import IR
 
 class Router(ABC):
     def __init__(self, **kwargs: Any) -> None:
-        """ Router class to map a quantum algorithm on the specific topology """
+        """ Generic router class """
         ...
 
     @abstractmethod

--- a/tests/test_circuit_builder.py
+++ b/tests/test_circuit_builder.py
@@ -65,7 +65,7 @@ class TestCircuitBuilder:
 
     def test_unknown_instruction(self) -> None:
         builder = CircuitBuilder(3)
-        with pytest.raises(ValueError, match="unknown instruction 'unknown'"):
+        with pytest.raises(AttributeError, match="has no attribute 'unknown'"):
             builder.unknown(0)
 
     def test_wrong_number_of_arguments(self) -> None:


### PR DESCRIPTION
* Autocompletion is not working for commands like `builder.CNOT`. Can be fixed by creating a `__dir__` for the dynamic attributes
* Calling commands by typing `builder.CNOT(0, 1)` in the interactive prompt fails, because the `__getattr__` returns also attributes that do not exist. In particular the attribute `__custom_documentations__` using by IPython intro inspection methods.
